### PR TITLE
not all vector tile json denote glyphs/sprites using relative paths now

### DIFF
--- a/debug/sample.html
+++ b/debug/sample.html
@@ -29,7 +29,7 @@
 <div id="map"></div>
 <script>
 var map = L.map('map').setView([45.526, -122.667], 13);
-var basemap = L.esri.Vector.basemap('Topographic').addTo(map);
+var basemap = L.esri.Vector.basemap('Gray').addTo(map);
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "prebuild": "mkdirp dist",
     "build": "rollup -c profiles/debug.js & rollup -c profiles/production.js",
-    "lint": "semistandard src/**/*.js | snazzy",
+    "lint": "semistandard | snazzy",
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "start": "nodemon --watch src --exec 'npm run build' & http-server -p 8765 -c-1 -o",

--- a/profiles/base.js
+++ b/profiles/base.js
@@ -10,6 +10,6 @@ config.plugins[0] = nodeResolve({
   main: true,
   browser: false,
   extensions: [ '.js', '.json' ]
-})
+});
 
 export default config;

--- a/profiles/production.js
+++ b/profiles/production.js
@@ -1,5 +1,5 @@
 import uglify from 'rollup-plugin-uglify';
-import config from './base.js'
+import config from './base.js';
 
 config.dest = 'dist/esri-leaflet-vector.js';
 config.sourceMap = 'dist/esri-leaflet-vector.js.map';

--- a/src/Basemap.js
+++ b/src/Basemap.js
@@ -56,9 +56,12 @@ export var Basemap = L.Layer.extend({
               name: metadata.name
             };
 
-            // set paths to sprite and glyphs
-            style.glyphs = url.replace('styles/root.json', style.glyphs.replace('../', ''));
-            style.sprite = url.replace('styles/root.json', style.sprite.replace('../', ''));
+            // if urls are provided using relative paths, we need to qualify them
+            if (style.glyphs.indexOf('https') === -1) {
+              // set paths to sprite and glyphs
+              style.glyphs = url.replace('styles/root.json', style.glyphs.replace('../', ''));
+              style.sprite = url.replace('styles/root.json', style.sprite.replace('../', ''));
+            }
 
             // set index
             style.index = metadata.tileInfo.tileMap;


### PR DESCRIPTION
resolves Esri/esri-leaflet/issues/861

steps to repro:
1. open http://esri.github.io/esri-leaflet/examples/vector-basemap.html
2. switch to Topographic, Gray, Dark Gray
3. basemap will fail to draw, errors regarding web request failures to malformed urls