### PR TITLE
1.0.4 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Upcoming changes][unreleased]
 
+## [1.0.4]
+
+### Added
+
+* `L.esri.Vector.layer` can now be used to display Vector Tile Services published using ArcGIS Pro.  (like [this one](http://www.arcgis.com/home/item.html?id=0bac0ffdc8634d9a9bc662bb8fa7547d))
+
 ## [1.0.3]
 
 ### Added
@@ -38,7 +44,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Initial Release
 
-[unreleased]: https://github.com/esri/esri-leaflet-vector/compare/v1.0.3...HEAD
+[unreleased]: https://github.com/esri/esri-leaflet-vector/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/esri/esri-leaflet-vector/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/esri/esri-leaflet-vector/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/esri/esri-leaflet-vector/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/esri/esri-leaflet-vector/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Take a look at the [live demo](http://esri.github.com/esri-leaflet/examples/vect
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
   <!-- Load libraries from CDN -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-beta.2/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@1.0.0-beta.2"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.0.1"></script>
 
   <!-- Esri Leaflet and Esri Leaflet Vector -->
   <script src="https://unpkg.com/esri-leaflet@2.0.3"></script>
@@ -65,10 +65,10 @@ Take a look at the [live demo](http://esri.github.com/esri-leaflet/examples/vect
 
 ## Dependencies
 
-* Leaflet version [1.0.0-beta.2](https://github.com/Leaflet/Leaflet/releases/tag/v1.0.0-beta.2) exhibits less flickering during pan/zoom, but more recent versions can be substituted.
+* Leaflet version [1.0.x](https://github.com/Leaflet/Leaflet/releases/tag/v1.0.1)
 * Esri Leaflet [2.0.3](https://github.com/Esri/esri-leaflet/releases/tag/v2.0.3) (or higher) is required.
-* [Mapbox GL Leaflet](https://github.com/patrickarlt/mapbox-gl-leaflet.git#leaflet-master)
-* [a fork of Mapbox GL JS](https://github.com/jgravois/mapbox-gl-js.git#esri-leaflet-renderer)
+* [Mapbox GL Leaflet](https://github.com/jgravois/mapbox-gl-leaflet.git#indexed-vector-sources)
+* [a fork of Mapbox GL JS](https://github.com/Esri/mapbox-gl-js.git#indexed-vector-sources)
 
 ## Resources
 

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Leaflet -->
-    <script src="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet-src.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.0-beta.2/leaflet.css">
+    <script src="https://cdn.jsdelivr.net/leaflet/1.0.1/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.1/leaflet.css">
 
     <!-- Esri Leaflet -->
     <script src="../node_modules/esri-leaflet/dist/esri-leaflet-debug.js"></script>
@@ -31,14 +31,14 @@
 var map = L.map('map').setView([45.526, -122.667], 3);
 
 // esri hosted basemap
-// L.esri.Vector.basemap('Topographic').addTo(map);
+L.esri.Vector.basemap('Topographic').addTo(map);
 
 // custom hosted basemap
 // L.esri.Vector.layer('bd505ce3efff479bb4e87b182f180159').addTo(map);
 
 // custom ArcGIS Pro published vector service
 // http://www.arcgis.com/home/item.html?id=0bac0ffdc8634d9a9bc662bb8fa7547d
-L.esri.Vector.layer('0bac0ffdc8634d9a9bc662bb8fa7547d').addTo(map);
+// L.esri.Vector.layer('0bac0ffdc8634d9a9bc662bb8fa7547d').addTo(map);
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "esri-leaflet-vector",
   "description": "Esri vector basemap plugin for Leaflet.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "",
   "bugs": {
     "url": "https://github.com/Esri/esri-leaflet-vector/issues"
   },
   "dependencies": {
     "esri-leaflet": "^2.0.3",
-    "leaflet": "1.0.0-beta.2",
+    "leaflet": "^1.0.0",
     "mapbox-gl": "git+https://github.com/Esri/mapbox-gl-js.git#indexed-vector-sources",
-    "mapbox-gl-leaflet": "git+https://github.com/patrickarlt/mapbox-gl-leaflet#leaflet-master"
+    "mapbox-gl-leaflet": "git+https://github.com/jgravois/mapbox-gl-leaflet#indexed-vector-sources"
   },
   "devDependencies": {
     "gh-release": "^2.0.0",
@@ -22,7 +22,8 @@
     "rollup-plugin-node-resolve": "^1.4.0",
     "rollup-plugin-uglify": "^0.3.1",
     "semistandard": "^7.0.5",
-    "snazzy": "^2.0.1"
+    "snazzy": "^2.0.1",
+    "watch": "^0.17.1"
   },
   "homepage": "https://github.com/Esri/esri-leaflet-vector#readme",
   "jsnext:main": "src/EsriLeafletVector.js",
@@ -45,7 +46,7 @@
     "lint": "semistandard | snazzy",
     "prepublish": "npm run build",
     "pretest": "npm run build",
-    "start": "nodemon --watch src --exec 'npm run build' & http-server -p 8765 -c-1 -o",
+    "start": "watch 'npm run build' src & http-server -p 8765 -c-1 -o",
     "test": "echo \"Error: no test specified\" && exit 1",
     "release": "./scripts/release.sh"
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "start": "watch 'npm run build' src & http-server -p 8765 -c-1 -o",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run lint",
     "release": "./scripts/release.sh"
   }
 }

--- a/src/Util.js
+++ b/src/Util.js
@@ -9,7 +9,6 @@ export function fetchMetadata (url, context) {
       request(style.sources.esri.url, {}, function (error, tileMetadata) {
         if (!error) {
           formatStyle(style, tileMetadata, url);
-          
           context._mapboxGL = L.mapboxGL({
             accessToken: 'ezree',
             style: style
@@ -26,14 +25,13 @@ export function fetchMetadata (url, context) {
 }
 
 export function formatStyle (style, metadata, styleUrl) {
-
   // if a relative path is referenced, the default style can be found in a standard location
   if (style.sources.esri.url && style.sources.esri.url.indexOf('http') === -1) {
     style.sources.esri.url = styleUrl.replace('/resources/styles/root.json', '');
   }
 
   // right now ArcGIS Pro published vector services have a slightly different signature
-  if (metadata.tiles && metadata.tiles[0].charAt(0) != '/') {
+  if (metadata.tiles && metadata.tiles[0].charAt(0) !== '/') {
     metadata.tiles[0] = '/' + metadata.tiles[0];
   }
 


### PR DESCRIPTION
* using [`jgravois/mapbox-gl-leaflet#indexed-vector-sources`](https://github.com/jgravois/mapbox-gl-leaflet/tree/indexed-vector-sources) as new wrapped dependency
* bumped to leaflet `1.x`