### PR TITLE
make sure to format tileMap urls appropriately

### DIFF
--- a/debug/sample.html
+++ b/debug/sample.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Leaflet -->
-    <script src="https://cdn.jsdelivr.net/leaflet/1.0.1/leaflet-src.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.1/leaflet.css">
+    <script src="https://cdn.jsdelivr.net/leaflet/1.0.2/leaflet-src.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.2/leaflet.css">
 
     <!-- Esri Leaflet -->
     <script src="../node_modules/esri-leaflet/dist/esri-leaflet-debug.js"></script>

--- a/src/Util.js
+++ b/src/Util.js
@@ -35,6 +35,10 @@ export function formatStyle (style, metadata, styleUrl) {
     metadata.tiles[0] = '/' + metadata.tiles[0];
   }
 
+  if (metadata.tileMap && metadata.tileMap.charAt(0) !== '/') {
+    metadata.tileMap = '/' + metadata.tileMap;
+  }
+
   style.sources.esri = {
     type: 'vector',
     scheme: 'xyz',


### PR DESCRIPTION
resolves #20 

apparently ArcGIS Pro generated vector tiles demarcate the url of their tilemap (if present) without the leading slash, unlike our hosted tilesets.

https://basemaps.arcgis.com/v1/arcgis/rest/services/World_Basemap/VectorTileServer?f=json

```js

{
  "currentVersion": 10.4,
  "name": "Streets",
  "tileMap": "/tilemap"
}
```

https://tiles.arcgis.com/tiles/znO8Hz1SuVVohYhZ/arcgis/rest/services/VectorTiles_Streetmap/VectorTileServer?f=json
```js
{
  "currentVersion": 10.41,
  "name": "VectorTiles_Streetmap",
  "tileMap": "tilemap"
}
```