### PR TITLE
make mapbox-gl an external dependency and add more explicit disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 > An ***experimental*** plugin for Esri Leaflet to visualize Vector tiles from ArcGIS Online. Built on top of [`mapbox-gl-leaflet`](https://github.com/mapbox/mapbox-gl-leaflet).
 
+## Disclaimer
+
+The code here is a house of cards that attempts to synchronize a [WebGLRenderingContext](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext) with a Leaflet map. It doesn't support rotation and can't draw more than one source at a time.
+
+For production applications, the [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/latest/sample-code/layers-vectortilelayer/index.html) is a much more appropriate choice.
+
 ## Example
 
 Take a look at the [live demo](http://esri.github.com/esri-leaflet/examples/vector-basemap.html).
@@ -21,13 +27,17 @@ Take a look at the [live demo](http://esri.github.com/esri-leaflet/examples/vect
   <title>Esri Vector Basemap</title>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
 
-  <!-- Load libraries from CDN -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+  <!-- Load Leaflet from CDN -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
+  <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+
+  <!-- Load Mapbox GL -->
+  <link rel="stylesheet" href="https://unpkg.com/mapbox-gl@0.44.1/dist/mapbox-gl.css"/>
+  <script src="https://unpkg.com/mapbox-gl@0.44.1/dist/mapbox-gl.js"></script>
 
   <!-- Esri Leaflet and Esri Leaflet Vector -->
-  <script src="https://unpkg.com/esri-leaflet@2.0.8/dist/esri-leaflet.js"></script>
-  <script src="https://unpkg.com/esri-leaflet-vector@1.0.7/dist/esri-leaflet-vector.js"></script>
+  <script src="https://unpkg.com/esri-leaflet@2.1.3/dist/esri-leaflet.js"></script>
+  <script src="../dist/esri-leaflet-vector-debug.js"></script>
 
   <style>
     body {margin:0;padding:0;}
@@ -92,7 +102,8 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 ## [Terms](https://github.com/Esri/esri-leaflet#terms)
 
 ## Licensing
-Copyright 2017 Esri
+
+Copyright 2018 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/debug/sample.html
+++ b/debug/sample.html
@@ -4,13 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- Leaflet -->
-    <script src="https://cdn.jsdelivr.net/leaflet/1.0.3/leaflet-src.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/leaflet/1.0.3/leaflet.css">
+    <!-- Load Leaflet from CDN -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+
+    <link rel="stylesheet" href="https://unpkg.com/mapbox-gl@0.44.1/dist/mapbox-gl.css"/>
+    <script src="https://unpkg.com/mapbox-gl@0.44.1/dist/mapbox-gl.js"></script>
+    <!--script src="../node_modules/mapbox-gl/dist/mapbox-gl.js"></script-->
 
     <!-- Esri Leaflet -->
-    <script src="../node_modules/esri-leaflet/dist/esri-leaflet-debug.js"></script>
-
+    <script src="https://unpkg.com/esri-leaflet@2.1.3/dist/esri-leaflet.js"></script>
     <script src="../dist/esri-leaflet-vector-debug.js"></script>
 
     <style>
@@ -31,7 +34,7 @@
 var map = L.map('map').setView([45.526, -122.667], 3);
 
 // esri hosted basemap
-L.esri.Vector.basemap('Newspaper').addTo(map);
+L.esri.Vector.basemap('Nova').addTo(map);
 
 // custom hosted basemap
 // L.esri.Vector.layer('bd505ce3efff479bb4e87b182f180159').addTo(map);
@@ -39,6 +42,10 @@ L.esri.Vector.basemap('Newspaper').addTo(map);
 // custom ArcGIS Pro published vector service
 // http://www.arcgis.com/home/item.html?id=0bac0ffdc8634d9a9bc662bb8fa7547d
 // L.esri.Vector.layer('0bac0ffdc8634d9a9bc662bb8fa7547d').addTo(map);
+
+// L.esri.featureLayer({
+//   url: "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3"
+// }).addTo(map);
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name" : "esri-leaflet-vector",
+  "name": "esri-leaflet-vector",
   "description": "Esri vector basemap plugin for Leaflet.",
   "version": "1.0.7",
   "author": "John Gravois <jgravois@esri.com> (http://johngravois.com)",
@@ -10,21 +10,21 @@
     "url": "https://github.com/Esri/esri-leaflet-vector/issues"
   },
   "dependencies": {
-    "esri-leaflet": "^2.0.3",
+    "esri-leaflet": "^2.1.2",
     "leaflet": "^1.0.0",
     "mapbox-gl": "git+https://github.com/Esri/mapbox-gl-js.git#indexed-vector-sources",
-    "mapbox-gl-leaflet": "^0.0.3"
+    "mapbox-gl-leaflet": "0.0.3"
   },
   "devDependencies": {
     "gh-release": "^2.0.0",
     "http-server": "^0.8.5",
     "mkdirp": "^0.5.1",
     "nodemon": "^1.9.2",
-    "rollup": "^0.25.4",
-    "rollup-plugin-commonjs": "^7.0.0",
-    "rollup-plugin-json": "^2.0.0",
-    "rollup-plugin-node-resolve": "^1.4.0",
-    "rollup-plugin-uglify": "^0.3.1",
+    "rollup": "^0.57.1",
+    "rollup-plugin-commonjs": "^9.1.0",
+    "rollup-plugin-json": "^2.3.0",
+    "rollup-plugin-node-resolve": "^3.3.0",
+    "rollup-plugin-uglify": "^3.0.0",
     "semistandard": "^7.0.5",
     "snazzy": "^2.0.1",
     "watch": "^0.17.1"

--- a/profiles/base.js
+++ b/profiles/base.js
@@ -1,15 +1,10 @@
 import config from '../node_modules/esri-leaflet/profiles/base.js';
-import nodeResolve from 'rollup-plugin-node-resolve';
 
-config.entry = 'src/EsriLeafletVector.js';
-config.moduleName = 'L.esri.Vector';
+config.input = 'src/EsriLeafletVector.js';
+config.output.name = 'L.esri.Vector';
 
-// is there a way to bundle mapbox-gl w/o a jsnext:main field? mapbox/mapbox-gl-js/issues/3767
-config.plugins[0] = nodeResolve({
-  jsnext: true,
-  main: true,
-  browser: false,
-  extensions: [ '.js', '.json' ]
-});
+// dont bundle mapbox-gl
+config.external.push('mapbox-gl');
+config.output.globals['mapbox-gl'] = 'mapboxgl';
 
 export default config;

--- a/profiles/debug.js
+++ b/profiles/debug.js
@@ -1,6 +1,6 @@
 import config from './base.js';
 
-config.dest = 'dist/esri-leaflet-vector-debug.js';
-config.sourceMap = 'inline';
+config.output.file = 'dist/esri-leaflet-vector-debug.js';
+config.output.sourcemap = true;
 
 export default config;

--- a/profiles/production.js
+++ b/profiles/production.js
@@ -1,8 +1,8 @@
 import uglify from 'rollup-plugin-uglify';
 import config from './base.js';
 
-config.dest = 'dist/esri-leaflet-vector.js';
-config.sourceMap = 'dist/esri-leaflet-vector.js.map';
+config.output.file = 'dist/esri-leaflet-vector.js';
+config.output.sourcemap = true;
 
 // use a Regex to preserve copyright text
 config.plugins.push(uglify({ output: { comments: /Institute, Inc/ } }));

--- a/src/Basemap.js
+++ b/src/Basemap.js
@@ -7,19 +7,24 @@ export var Basemap = L.Layer.extend({
     URLPREFIX: 'https://www.arcgis.com/sharing/rest/content/items/',
     URLSUFFIX: '/resources/styles/root.json',
     STYLES: {
-      'DarkGray': '57436c01bc754dbb87dfb636b6484022',
-      'Gray': '1e47168d181248e491541ffd5a91c0de',
-      'Hybrid': 'af6063d6906c4eb589dfe03819610660',
-      'Navigation': 'e19e9330bf08490ca8353d76b5e2e658',
-      'Streets': 'a60a37a27cc140ddad15f919cd5a69f2',
-      'StreetsNight': '92c551c9f07b4147846aae273e822714',
-      'StreetsRelief': '78c0a9ab4fbf4198a8b951848aab19d8',
-      'Topographic': '86d5ed4b6dc741de9dad5f0fbe09ae95',
+      'DarkGray': '5e9b3685f4c24d8781073dd928ebda50',
+      'DarkGrayLabels' : '747cb7a5329c478cbe6981076cc879c5',
+      'Gray': '291da5eab3a0412593b66d384379f89f',
+      'Hybrid': '30d6b8271e1849cd9c3042060001f425',
+      'Navigation': '63c47b7177f946b49902c24129b87252',
+      'Streets': 'de26a3cf4cc9451298ea173c4b324736',
+      'StreetsNight': '86f556a2d1fd468181855a35e344567f',
+      'StreetsRelief': '41597245552743d5910de614d47e748c',
+      'Topographic': '7dc6cea0b1764a1f9af2e679f642f0f5',
       'Spring': '267f44f08a844c7abee2b62b00600540',
-      'Newspaper': '4f4843d99c34436f82920932317893ae',
-      'MidCentury': '763884983d3544c0a418a97992881fce',
-      'ModernAntique': '996d9e7a3aac4514bb692ce7a990f1c1',
-      'BlackAndWhite': '3161443179244702a5e0449010013b54'
+      'Newspaper': 'dfb04de5f3144a80bc3f9f336228d24a',
+      'MidCentury': '7675d44bb1e4428aa2c30a9b68f97822',
+      'ModernAntique': 'effe3475f05a4d608e66fd6eeb2113c0',
+      'BlackAndWhite': '3161443179244702a5e0449010013b54',
+      'ColoredPencil': '4cf7e1fb9f254dcda9c8fbadb15cf0f8',
+      'HumanGeography': '97fa1365da1e43eabb90d0364326bc2d',
+      'DarkHumanGeography': 'd7397603e9274052808839b70812be50',
+      'Nova': '75f4dfdff19e445395653121a95a85db'
     }
   },
 
@@ -39,7 +44,6 @@ export var Basemap = L.Layer.extend({
 
   onAdd: function (map) {
     this._map = map;
-
     Util.setEsriAttribution(map);
 
     if (map.attributionControl) {
@@ -71,11 +75,20 @@ export var Basemap = L.Layer.extend({
   _asyncAdd: function () {
     var map = this._map;
 
+    // thought it was just me, but apparently its not easy to mixin two different styles
+    // https://github.com/mapbox/mapbox-gl-js/issues/4000
+    // https://www.mapbox.com/mapbox-gl-js/style-spec/#sources
+    // if (map._gl) {
+      // map._gl._glMap.addSource("second", this._mapboxGL.options.style.sources.esri);
+    // }
+    
     // set the background color of the map to the background color of the tiles
     map.getContainer().style.background = this._mapboxGL.options.style.layers[0].paint['background-color'];
 
     map.on('moveend', Util._updateMapAttribution);
     this._mapboxGL.addTo(map, this);
+    // map._gl = this._mapboxGL;
+    
   }
 });
 

--- a/src/Basemap.js
+++ b/src/Basemap.js
@@ -8,7 +8,6 @@ export var Basemap = L.Layer.extend({
     URLSUFFIX: '/resources/styles/root.json',
     STYLES: {
       'DarkGray': '5e9b3685f4c24d8781073dd928ebda50',
-      'DarkGrayLabels' : '747cb7a5329c478cbe6981076cc879c5',
       'Gray': '291da5eab3a0412593b66d384379f89f',
       // 'Hybrid': '30d6b8271e1849cd9c3042060001f425', only loads labels
       'Navigation': '63c47b7177f946b49902c24129b87252',
@@ -74,17 +73,15 @@ export var Basemap = L.Layer.extend({
 
   _asyncAdd: function () {
     var map = this._map;
-
     // thought it was just me, but apparently its not easy to mixin two different styles
     // https://github.com/mapbox/mapbox-gl-js/issues/4000
-    
+
     // set the background color of the map to the background color of the tiles
     map.getContainer().style.background = this._mapboxGL.options.style.layers[0].paint['background-color'];
 
     map.on('moveend', Util._updateMapAttribution);
     this._mapboxGL.addTo(map, this);
     // map._gl = this._mapboxGL;
-    
   }
 });
 

--- a/src/Basemap.js
+++ b/src/Basemap.js
@@ -10,11 +10,11 @@ export var Basemap = L.Layer.extend({
       'DarkGray': '5e9b3685f4c24d8781073dd928ebda50',
       'DarkGrayLabels' : '747cb7a5329c478cbe6981076cc879c5',
       'Gray': '291da5eab3a0412593b66d384379f89f',
-      'Hybrid': '30d6b8271e1849cd9c3042060001f425',
+      // 'Hybrid': '30d6b8271e1849cd9c3042060001f425', only loads labels
       'Navigation': '63c47b7177f946b49902c24129b87252',
       'Streets': 'de26a3cf4cc9451298ea173c4b324736',
-      'StreetsNight': '86f556a2d1fd468181855a35e344567f',
-      'StreetsRelief': '41597245552743d5910de614d47e748c',
+      // 'StreetsNight': '86f556a2d1fd468181855a35e344567f', fails to load
+      'StreetsRelief': 'b266e6d17fc345b498345613930fbd76',
       'Topographic': '7dc6cea0b1764a1f9af2e679f642f0f5',
       'Spring': '267f44f08a844c7abee2b62b00600540',
       'Newspaper': 'dfb04de5f3144a80bc3f9f336228d24a',
@@ -22,8 +22,8 @@ export var Basemap = L.Layer.extend({
       'ModernAntique': 'effe3475f05a4d608e66fd6eeb2113c0',
       'BlackAndWhite': '3161443179244702a5e0449010013b54',
       'ColoredPencil': '4cf7e1fb9f254dcda9c8fbadb15cf0f8',
-      'HumanGeography': '97fa1365da1e43eabb90d0364326bc2d',
-      'DarkHumanGeography': 'd7397603e9274052808839b70812be50',
+      // 'HumanGeography': '97fa1365da1e43eabb90d0364326bc2d', doesn't load
+      // 'DarkHumanGeography': 'd7397603e9274052808839b70812be50', // loads, but not much
       'Nova': '75f4dfdff19e445395653121a95a85db'
     }
   },
@@ -77,10 +77,6 @@ export var Basemap = L.Layer.extend({
 
     // thought it was just me, but apparently its not easy to mixin two different styles
     // https://github.com/mapbox/mapbox-gl-js/issues/4000
-    // https://www.mapbox.com/mapbox-gl-js/style-spec/#sources
-    // if (map._gl) {
-      // map._gl._glMap.addSource("second", this._mapboxGL.options.style.sources.esri);
-    // }
     
     // set the background color of the map to the background color of the tiles
     map.getContainer().style.background = this._mapboxGL.options.style.layers[0].paint['background-color'];


### PR DESCRIPTION
also introduces support for `v2` basemaps

resolves #31, #39, #43 (and hopefully #22)
 
1. `npm install && npm start`
2. http://localhost:8765/debug/sample.html (which includes a new script tag for mapbox-gl)

in refactoring the build system i noticed that the drawing behavior when you load the latest version of `mapbox-gl` is less glitchy and overall more visually appealing. the downside is that it logs lots of messages to the console, attempts to fetch tiles from our indexed services that were never cached and is incapable of loading a couple of the `v2` basemaps.

the benefit of the new approach is that if any developers don't like the new behavior, we can commit a built version of our stale fork up for them to use instead. either way its a breaking change, but i can live with that if folks can actually build the source and debug locally again.

 