### PR TITLE
cap native zoom at 15

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -49,7 +49,15 @@ export function formatStyle (style, metadata, styleUrl) {
       style.sources.esri.url + metadata.tiles[0]
     ],
     description: metadata.description,
-    name: metadata.name
+    name: metadata.name,
+    /* mapbox-gl-js does not respect the indexing of esri tiles
+    because we cache to different zoom levels depending on feature density. articifially capping at 15, but 404s will still be encountered when zooming in tight in rural areas.
+
+    the *real* solution would be to make intermittent calls to our tilemap and update the maxzoom of the layer internally.
+
+    reference implementation: https://github.com/openstreetmap/iD/pull/5029
+    */
+    maxzoom: 15
   };
 
   if (style.glyphs.indexOf('http') === -1) {


### PR DESCRIPTION
right now we start seeing 404s even in places like NYC.

this is a lazy approach to support deep zoom only in areas with good feature density.