### PR TITLE
Fixes #29 - detects if item is a hosted service rather than assuming all non-esri tiles do not have a style.json.

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -40,12 +40,12 @@ export var Layer = L.Layer.extend({
                 request(styleUrl, {}, function (error, style) {
                   if (!error) {
                     formatStyle(style, tileMetadata, styleUrl);
-   
+
                     this._mapboxGL = L.mapboxGL({
                       accessToken: 'ezree',
                       style: style
                     });
-   
+
                     this._ready = true;
                     this.fire('ready', {}, true);
                   }
@@ -55,7 +55,7 @@ export var Layer = L.Layer.extend({
           } else {
             // custom symbology applied to hosted basemap tiles
             fetchMetadata(itemMetadataUrl + '/resources/styles/root.json', this);
-           }
+          }
         }
       }, this);
     } else {

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -23,7 +23,7 @@ export var Layer = L.Layer.extend({
           tileUrl = metadata.url;
 
           // custom tileset published using ArcGIS Pro
-          if (tileUrl.indexOf('basemaps.arcgis.com') === -1) {
+          if (metadata.typeKeywords.indexOf("Hosted Service") !== -1) {
             this._customTileset = true;
             // if copyright info was published, display it.
             if (metadata.accessInformation) {
@@ -40,12 +40,12 @@ export var Layer = L.Layer.extend({
                 request(styleUrl, {}, function (error, style) {
                   if (!error) {
                     formatStyle(style, tileMetadata, styleUrl);
-
+   
                     this._mapboxGL = L.mapboxGL({
                       accessToken: 'ezree',
                       style: style
                     });
-
+   
                     this._ready = true;
                     this.fire('ready', {}, true);
                   }
@@ -55,7 +55,7 @@ export var Layer = L.Layer.extend({
           } else {
             // custom symbology applied to hosted basemap tiles
             fetchMetadata(itemMetadataUrl + '/resources/styles/root.json', this);
-          }
+           }
         }
       }, this);
     } else {


### PR DESCRIPTION
Update layer to check if tiles are hosted service to fix issue where custom styles for non Esri, self published or distributer published tiles were not detected. Fixes #29 