### PR TITLE
check if layer layout property exists before accessing

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -143,7 +143,7 @@ export function formatStyle (style, styleUrl, metadata, token) {
   // if any layer in style.layers has a layout.text-font property (it will be any array of strings) remove all items in the array after the first
   for (var layerIndex = 0; layerIndex < style.layers.length; layerIndex++) {
     var layer = style.layers[layerIndex];
-    if (layer.layout['text-font'] && layer.layout['text-font'].length > 1) {
+    if (layer.layout && layer.layout['text-font'] && layer.layout['text-font'].length > 1) {
       layer.layout['text-font'] = [layer.layout['text-font'][0]];
     }
   }


### PR DESCRIPTION
for some sources, e.g Esri's world contour service at https://basemaps.arcgis.com/arcgis/rest/services/World_Contours_v2/VectorTileServer , the layout property does not exist. As a result the plugin throws an error and we can't currently add the service to a map.