### PR TITLE
add support for items with non-esri source names

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
   extends: 'eslint-config-semistandard',
-  plugins: [
-    'chai-friendly'
-  ],
+  plugins: ['chai-friendly'],
   rules: {
     'no-var': 'off',
     'no-unused-expressions': 0,

--- a/examples/contour.html
+++ b/examples/contour.html
@@ -1,0 +1,46 @@
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <title>Esri Leaflet Vector Quickstart</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <!-- Load Leaflet from CDN -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.0/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.5.0/dist/leaflet.js"></script>
+
+  <!--
+    Load mapbox-gl from CDN for dev/debug purposes because it is not bundled in Esri Leaflet Vector's dev/debug code
+    (note also that loading mapbox-gl.css is not necessary)
+  -->
+  <script src="https://unpkg.com/mapbox-gl@1.4.0/dist/mapbox-gl.js"></script>
+
+  <!-- Esri Leaflet and Esri Leaflet Vector plugin dev/debug version -->
+  <script src="https://unpkg.com/esri-leaflet@2.3.0/dist/esri-leaflet.js"></script>
+  <script src="../dist/esri-leaflet-vector-debug.js"></script>
+
+  <style>
+    html,
+    body {
+      margin: 0;
+    }
+
+    #map {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="map"></div>
+
+  <script>
+    var map = L.map("map", {}).setView([34.0739, -118.2400], 15);
+    
+    // should load and show contours around Dodger Stadium
+    L.esri.Vector.vectorTileLayer("18d32a699af64bfba4e78eba5a4dd705").addTo(map);
+  </script>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "build": "rollup -c profiles/debug.js & rollup -c profiles/production.js",
     "build-dev": "rollup -c profiles/debug.js",
     "fix": "semistandard --fix",
-    "lint": "eslint {src,spec}/**/*.js",
+    "lint": "eslint src/**/*.js",
     "prepublishOnly": "npm run build",
     "start-watch": "watch \"npm run build\" src",
     "start-watch-dev": "watch \"npm run build-dev\" src",

--- a/spec/VectorBasemapLayerSpec.js
+++ b/spec/VectorBasemapLayerSpec.js
@@ -1,11 +1,10 @@
 /* eslint-env mocha */
 
-var itemId = "287c07ef752246d08bb4712fd4b74438";
-var basemapKey = "ArcGIS:Streets";
+var itemId = '287c07ef752246d08bb4712fd4b74438';
+var basemapKey = 'ArcGIS:Streets';
 var apikey = '1234';
 
 describe('VectorBasemapLayer', function () {
-
   it('should have a L.esri.vectorBasemapLayer alias', function () {
     console.log('L.esri.Vector.vectorBasemapLayer', L.esri.Vector.vectorBasemapLayer);
 
@@ -15,7 +14,6 @@ describe('VectorBasemapLayer', function () {
   });
 
   it('should save the key from the constructor - itemID', function () {
-
     const layer = L.esri.Vector.vectorBasemapLayer(itemId, {
       apikey: apikey
     });
@@ -23,15 +21,13 @@ describe('VectorBasemapLayer', function () {
     expect(layer.options.key).to.equal(itemId);
   });
 
-
   it('should error if no api key or token', function () {
     expect(function () {
       L.esri.Vector.vectorBasemapLayer(basemapKey, {});
-    }).to.throw("API Key or token is required for vectorBasemapLayer.");
+    }).to.throw('API Key or token is required for vectorBasemapLayer.');
   });
 
   it('should save the key from the constructor - enumeration basemap key', function () {
-
     const layer = L.esri.Vector.vectorBasemapLayer(basemapKey, {
       apikey: apikey
     });
@@ -40,7 +36,6 @@ describe('VectorBasemapLayer', function () {
   });
 
   it('should save the api key from the constructor', function () {
-
     const layer = L.esri.Vector.vectorBasemapLayer(basemapKey, {
       apikey: apikey
     });
@@ -49,7 +44,6 @@ describe('VectorBasemapLayer', function () {
   });
 
   it('should save the token as apikey from the constructor', function () {
-
     var layer = new L.esri.Vector.VectorBasemapLayer(basemapKey, {
       token: apikey
     });
@@ -59,7 +53,7 @@ describe('VectorBasemapLayer', function () {
 
   describe('_getAttributionUrls', function () {
     it('should handle OSM keys', function () {
-      var key = "OSM:Standard";
+      var key = 'OSM:Standard';
       var layer = new L.esri.Vector.VectorBasemapLayer(key, {
         token: apikey
       });
@@ -69,7 +63,7 @@ describe('VectorBasemapLayer', function () {
     });
 
     it('should handle ArcGIS Imagery keys', function () {
-      var key = "ArcGIS:Imagery";
+      var key = 'ArcGIS:Imagery';
       var layer = new L.esri.Vector.VectorBasemapLayer(key, {
         token: apikey
       });
@@ -80,7 +74,7 @@ describe('VectorBasemapLayer', function () {
     });
 
     it('should handle ArcGIS non-Imagery keys', function () {
-      var key = "ArcGIS:Streets";
+      var key = 'ArcGIS:Streets';
       var layer = new L.esri.Vector.VectorBasemapLayer(key, {
         token: apikey
       });
@@ -89,6 +83,4 @@ describe('VectorBasemapLayer', function () {
       expect(attributionUrls[0]).to.equal('https://static.arcgis.com/attribution/Vector/World_Basemap_v2');
     });
   });
-
-
 });

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,14 +1,17 @@
-import { latLng, latLngBounds } from 'leaflet';
-import { request, Support, Util } from 'esri-leaflet';
+import { latLng, latLngBounds } from "leaflet";
+import { request, Support, Util } from "esri-leaflet";
 
 /*
   utility to establish a URL for the basemap styles API
   used primarily by VectorBasemapLayer.js
 */
-export function getBasemapStyleUrl (key, apikey) {
-  var url = 'https://basemaps-api.arcgis.com/arcgis/rest/services/styles/' + key + '?type=style';
+export function getBasemapStyleUrl(key, apikey) {
+  var url =
+    "https://basemaps-api.arcgis.com/arcgis/rest/services/styles/" +
+    key +
+    "?type=style";
   if (apikey) {
-    url = url + '&apiKey=' + apikey;
+    url = url + "&apiKey=" + apikey;
   }
   return url;
 }
@@ -17,7 +20,7 @@ export function getBasemapStyleUrl (key, apikey) {
   utilities to communicate with custom user styles via an ITEM ID or SERVICE URL
   used primarily by VectorTileLayer.js
 */
-export function loadStyle (idOrUrl, options, callback) {
+export function loadStyle(idOrUrl, options, callback) {
   var httpRegex = /^https?:\/\//;
   var serviceRegex = /\/VectorTileServer\/?$/;
 
@@ -30,22 +33,22 @@ export function loadStyle (idOrUrl, options, callback) {
   }
 }
 
-export function loadService (serviceUrl, options, callback) {
+export function loadService(serviceUrl, options, callback) {
   var params = options.token ? { token: options.token } : {};
   request(serviceUrl, params, callback);
 }
 
-function loadItem (itemId, options, callback) {
+function loadItem(itemId, options, callback) {
   var params = options.token ? { token: options.token } : {};
-  var url = 'https://www.arcgis.com/sharing/rest/content/items/' + itemId;
+  var url = "https://www.arcgis.com/sharing/rest/content/items/" + itemId;
   request(url, params, callback);
 }
 
-function loadStyleFromItem (itemId, options, callback) {
+function loadStyleFromItem(itemId, options, callback) {
   var itemStyleUrl =
-    'https://www.arcgis.com/sharing/rest/content/items/' +
+    "https://www.arcgis.com/sharing/rest/content/items/" +
     itemId +
-    '/resources/styles/root.json';
+    "/resources/styles/root.json";
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
     if (error) {
@@ -56,14 +59,19 @@ function loadStyleFromItem (itemId, options, callback) {
         loadStyleFromService(item.url, options, callback);
       });
     } else {
-      loadService(style.sources.esri.url, options, function (error, service) {
-        callback(error, style, itemStyleUrl, service, style.sources.esri.url);
+      loadItem(itemId, options, function (error, item) {
+        if (error) {
+          console.error(error);
+        }
+        loadService(item.url, options, function (error, service) {
+          callback(error, style, itemStyleUrl, service, item.url);
+        });
       });
     }
   });
 }
 
-function loadStyleFromService (serviceUrl, options, callback) {
+function loadStyleFromService(serviceUrl, options, callback) {
   loadService(serviceUrl, options, function (error, service) {
     if (error) {
       console.error(error);
@@ -71,18 +79,16 @@ function loadStyleFromService (serviceUrl, options, callback) {
 
     var defaultStylesUrl;
     if (
-      serviceUrl.charAt(0) !== '/' &&
-      service.defaultStyles.charAt(service.defaultStyles.length - 1) !== '/'
+      serviceUrl.charAt(0) !== "/" &&
+      service.defaultStyles.charAt(service.defaultStyles.length - 1) !== "/"
     ) {
-      defaultStylesUrl = serviceUrl + '/' + service.defaultStyles + '/root.json';
+      defaultStylesUrl =
+        serviceUrl + "/" + service.defaultStyles + "/root.json";
     } else {
-      defaultStylesUrl = serviceUrl + service.defaultStyles + '/root.json';
+      defaultStylesUrl = serviceUrl + service.defaultStyles + "/root.json";
     }
 
-    loadStyleFromUrl(defaultStylesUrl, options, function (
-      error,
-      style
-    ) {
+    loadStyleFromUrl(defaultStylesUrl, options, function (error, style) {
       if (error) {
         console.error(error);
       }
@@ -91,12 +97,12 @@ function loadStyleFromService (serviceUrl, options, callback) {
   });
 }
 
-function loadStyleFromUrl (styleUrl, options, callback) {
+function loadStyleFromUrl(styleUrl, options, callback) {
   var params = options.token ? { token: options.token } : {};
   request(styleUrl, params, callback);
 }
 
-export function formatStyle (style, styleUrl, metadata, token) {
+export function formatStyle(style, styleUrl, metadata, token) {
   // transforms style object in place and also returns it
 
   // modify each source in style.sources
@@ -105,67 +111,66 @@ export function formatStyle (style, styleUrl, metadata, token) {
     var source = style.sources[sourcesKeys[sourceIndex]];
 
     // if a relative path is referenced, the default style can be found in a standard location
-    if (source.url.indexOf('http') === -1) {
-      source.url = styleUrl.replace(
-        '/resources/styles/root.json',
-        ''
-      );
+    if (source.url.indexOf("http") === -1) {
+      source.url = styleUrl.replace("/resources/styles/root.json", "");
     }
 
     // add tiles property if missing
     if (!source.tiles) {
       // right now ArcGIS Pro published vector services have a slightly different signature
       // the '/' is needed in the URL string concatenation below for source.tiles
-      if (metadata.tiles && metadata.tiles[0].charAt(0) !== '/') {
-        metadata.tiles[0] = '/' + metadata.tiles[0];
+      if (metadata.tiles && metadata.tiles[0].charAt(0) !== "/") {
+        metadata.tiles[0] = "/" + metadata.tiles[0];
       }
 
-      source.tiles = [
-        source.url +
-        metadata.tiles[0]
-      ];
+      source.tiles = [source.url + metadata.tiles[0]];
     }
 
     // add the token to the source url and tiles properties as a query param
-    source.url += (token ? '?token=' + token : '');
-    source.tiles[0] += (token ? '?token=' + token : '');
+    source.url += token ? "?token=" + token : "";
+    source.tiles[0] += token ? "?token=" + token : "";
 
     // add minzoom and maxzoom to each source based on the service metadata
     source.minzoom = metadata.tileInfo.lods[0].level;
-    source.maxzoom = metadata.tileInfo.lods[metadata.tileInfo.lods.length - 1].level;
+    source.maxzoom =
+      metadata.tileInfo.lods[metadata.tileInfo.lods.length - 1].level;
   }
 
   // add the attribution and copyrightText properties to the last source in style.sources based on the service metadata
   var lastSource = style.sources[sourcesKeys[sourcesKeys.length - 1]];
-  lastSource.attribution = metadata.copyrightText || '';
-  lastSource.copyrightText = metadata.copyrightText || '';
+  lastSource.attribution = metadata.copyrightText || "";
+  lastSource.copyrightText = metadata.copyrightText || "";
 
   // if any layer in style.layers has a layout.text-font property (it will be any array of strings) remove all items in the array after the first
   for (var layerIndex = 0; layerIndex < style.layers.length; layerIndex++) {
     var layer = style.layers[layerIndex];
-    if (layer.layout && layer.layout['text-font'] && layer.layout['text-font'].length > 1) {
-      layer.layout['text-font'] = [layer.layout['text-font'][0]];
+    if (
+      layer.layout &&
+      layer.layout["text-font"] &&
+      layer.layout["text-font"].length > 1
+    ) {
+      layer.layout["text-font"] = [layer.layout["text-font"][0]];
     }
   }
 
   // resolve absolute URLs for style.sprite and style.glyphs
-  if (style.sprite.indexOf('http') === -1) {
+  if (style.sprite.indexOf("http") === -1) {
     style.sprite = styleUrl.replace(
-      'styles/root.json',
-      style.sprite.replace('../', '')
+      "styles/root.json",
+      style.sprite.replace("../", "")
     );
   }
 
-  if (style.glyphs.indexOf('http') === -1) {
+  if (style.glyphs.indexOf("http") === -1) {
     style.glyphs = styleUrl.replace(
-      'styles/root.json',
-      style.glyphs.replace('../', '')
+      "styles/root.json",
+      style.glyphs.replace("../", "")
     );
   }
 
   // add the token to the style.sprite and style.glyphs properties as a query param
-  style.sprite += (token ? '?token=' + token : '');
-  style.glyphs += (token ? '?token=' + token : '');
+  style.sprite += token ? "?token=" + token : "";
+  style.glyphs += token ? "?token=" + token : "";
 
   return style;
 }
@@ -174,7 +179,7 @@ export function formatStyle (style, styleUrl, metadata, token) {
   utility to assist with dynamic attribution data
   used primarily by VectorBasemapLayer.js
 */
-export function getAttributionData (url, map) {
+export function getAttributionData(url, map) {
   if (Support.cors) {
     request(url, {}, function (error, attributions) {
       if (error) {
@@ -193,7 +198,7 @@ export function getAttributionData (url, map) {
             score: coverageArea.score,
             bounds: latLngBounds(southWest, northEast),
             minZoom: coverageArea.zoomMin,
-            maxZoom: coverageArea.zoomMax
+            maxZoom: coverageArea.zoomMax,
           });
         }
       }

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,17 +1,17 @@
-import { latLng, latLngBounds } from "leaflet";
-import { request, Support, Util } from "esri-leaflet";
+import { latLng, latLngBounds } from 'leaflet';
+import { request, Support, Util } from 'esri-leaflet';
 
 /*
   utility to establish a URL for the basemap styles API
   used primarily by VectorBasemapLayer.js
 */
-export function getBasemapStyleUrl(key, apikey) {
+export function getBasemapStyleUrl (key, apikey) {
   var url =
-    "https://basemaps-api.arcgis.com/arcgis/rest/services/styles/" +
+    'https://basemaps-api.arcgis.com/arcgis/rest/services/styles/' +
     key +
-    "?type=style";
+    '?type=style';
   if (apikey) {
-    url = url + "&apiKey=" + apikey;
+    url = url + '&apiKey=' + apikey;
   }
   return url;
 }
@@ -20,7 +20,7 @@ export function getBasemapStyleUrl(key, apikey) {
   utilities to communicate with custom user styles via an ITEM ID or SERVICE URL
   used primarily by VectorTileLayer.js
 */
-export function loadStyle(idOrUrl, options, callback) {
+export function loadStyle (idOrUrl, options, callback) {
   var httpRegex = /^https?:\/\//;
   var serviceRegex = /\/VectorTileServer\/?$/;
 
@@ -33,22 +33,22 @@ export function loadStyle(idOrUrl, options, callback) {
   }
 }
 
-export function loadService(serviceUrl, options, callback) {
+export function loadService (serviceUrl, options, callback) {
   var params = options.token ? { token: options.token } : {};
   request(serviceUrl, params, callback);
 }
 
-function loadItem(itemId, options, callback) {
+function loadItem (itemId, options, callback) {
   var params = options.token ? { token: options.token } : {};
-  var url = "https://www.arcgis.com/sharing/rest/content/items/" + itemId;
+  var url = 'https://www.arcgis.com/sharing/rest/content/items/' + itemId;
   request(url, params, callback);
 }
 
-function loadStyleFromItem(itemId, options, callback) {
+function loadStyleFromItem (itemId, options, callback) {
   var itemStyleUrl =
-    "https://www.arcgis.com/sharing/rest/content/items/" +
+    'https://www.arcgis.com/sharing/rest/content/items/' +
     itemId +
-    "/resources/styles/root.json";
+    '/resources/styles/root.json';
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
     if (error) {
@@ -71,7 +71,7 @@ function loadStyleFromItem(itemId, options, callback) {
   });
 }
 
-function loadStyleFromService(serviceUrl, options, callback) {
+function loadStyleFromService (serviceUrl, options, callback) {
   loadService(serviceUrl, options, function (error, service) {
     if (error) {
       console.error(error);
@@ -79,13 +79,13 @@ function loadStyleFromService(serviceUrl, options, callback) {
 
     var defaultStylesUrl;
     if (
-      serviceUrl.charAt(0) !== "/" &&
-      service.defaultStyles.charAt(service.defaultStyles.length - 1) !== "/"
+      serviceUrl.charAt(0) !== '/' &&
+      service.defaultStyles.charAt(service.defaultStyles.length - 1) !== '/'
     ) {
       defaultStylesUrl =
-        serviceUrl + "/" + service.defaultStyles + "/root.json";
+        serviceUrl + '/' + service.defaultStyles + '/root.json';
     } else {
-      defaultStylesUrl = serviceUrl + service.defaultStyles + "/root.json";
+      defaultStylesUrl = serviceUrl + service.defaultStyles + '/root.json';
     }
 
     loadStyleFromUrl(defaultStylesUrl, options, function (error, style) {
@@ -97,12 +97,12 @@ function loadStyleFromService(serviceUrl, options, callback) {
   });
 }
 
-function loadStyleFromUrl(styleUrl, options, callback) {
+function loadStyleFromUrl (styleUrl, options, callback) {
   var params = options.token ? { token: options.token } : {};
   request(styleUrl, params, callback);
 }
 
-export function formatStyle(style, styleUrl, metadata, token) {
+export function formatStyle (style, styleUrl, metadata, token) {
   // transforms style object in place and also returns it
 
   // modify each source in style.sources
@@ -111,24 +111,24 @@ export function formatStyle(style, styleUrl, metadata, token) {
     var source = style.sources[sourcesKeys[sourceIndex]];
 
     // if a relative path is referenced, the default style can be found in a standard location
-    if (source.url.indexOf("http") === -1) {
-      source.url = styleUrl.replace("/resources/styles/root.json", "");
+    if (source.url.indexOf('http') === -1) {
+      source.url = styleUrl.replace('/resources/styles/root.json', '');
     }
 
     // add tiles property if missing
     if (!source.tiles) {
       // right now ArcGIS Pro published vector services have a slightly different signature
       // the '/' is needed in the URL string concatenation below for source.tiles
-      if (metadata.tiles && metadata.tiles[0].charAt(0) !== "/") {
-        metadata.tiles[0] = "/" + metadata.tiles[0];
+      if (metadata.tiles && metadata.tiles[0].charAt(0) !== '/') {
+        metadata.tiles[0] = '/' + metadata.tiles[0];
       }
 
       source.tiles = [source.url + metadata.tiles[0]];
     }
 
     // add the token to the source url and tiles properties as a query param
-    source.url += token ? "?token=" + token : "";
-    source.tiles[0] += token ? "?token=" + token : "";
+    source.url += token ? '?token=' + token : '';
+    source.tiles[0] += token ? '?token=' + token : '';
 
     // add minzoom and maxzoom to each source based on the service metadata
     source.minzoom = metadata.tileInfo.lods[0].level;
@@ -138,39 +138,39 @@ export function formatStyle(style, styleUrl, metadata, token) {
 
   // add the attribution and copyrightText properties to the last source in style.sources based on the service metadata
   var lastSource = style.sources[sourcesKeys[sourcesKeys.length - 1]];
-  lastSource.attribution = metadata.copyrightText || "";
-  lastSource.copyrightText = metadata.copyrightText || "";
+  lastSource.attribution = metadata.copyrightText || '';
+  lastSource.copyrightText = metadata.copyrightText || '';
 
   // if any layer in style.layers has a layout.text-font property (it will be any array of strings) remove all items in the array after the first
   for (var layerIndex = 0; layerIndex < style.layers.length; layerIndex++) {
     var layer = style.layers[layerIndex];
     if (
       layer.layout &&
-      layer.layout["text-font"] &&
-      layer.layout["text-font"].length > 1
+      layer.layout['text-font'] &&
+      layer.layout['text-font'].length > 1
     ) {
-      layer.layout["text-font"] = [layer.layout["text-font"][0]];
+      layer.layout['text-font'] = [layer.layout['text-font'][0]];
     }
   }
 
   // resolve absolute URLs for style.sprite and style.glyphs
-  if (style.sprite.indexOf("http") === -1) {
+  if (style.sprite.indexOf('http') === -1) {
     style.sprite = styleUrl.replace(
-      "styles/root.json",
-      style.sprite.replace("../", "")
+      'styles/root.json',
+      style.sprite.replace('../', '')
     );
   }
 
-  if (style.glyphs.indexOf("http") === -1) {
+  if (style.glyphs.indexOf('http') === -1) {
     style.glyphs = styleUrl.replace(
-      "styles/root.json",
-      style.glyphs.replace("../", "")
+      'styles/root.json',
+      style.glyphs.replace('../', '')
     );
   }
 
   // add the token to the style.sprite and style.glyphs properties as a query param
-  style.sprite += token ? "?token=" + token : "";
-  style.glyphs += token ? "?token=" + token : "";
+  style.sprite += token ? '?token=' + token : '';
+  style.glyphs += token ? '?token=' + token : '';
 
   return style;
 }
@@ -179,7 +179,7 @@ export function formatStyle(style, styleUrl, metadata, token) {
   utility to assist with dynamic attribution data
   used primarily by VectorBasemapLayer.js
 */
-export function getAttributionData(url, map) {
+export function getAttributionData (url, map) {
   if (Support.cors) {
     request(url, {}, function (error, attributions) {
       if (error) {
@@ -198,7 +198,7 @@ export function getAttributionData(url, map) {
             score: coverageArea.score,
             bounds: latLngBounds(southWest, northEast),
             minZoom: coverageArea.zoomMin,
-            maxZoom: coverageArea.zoomMax,
+            maxZoom: coverageArea.zoomMax
           });
         }
       }


### PR DESCRIPTION
This should resolve https://github.com/Esri/esri-leaflet-vector/issues/72 allowing for non-esri sources. See the included example.