### PR TITLE
94-non-web-merc-warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Upcoming changes][unreleased]
 
+### Added
+
+* New README documentation and a developer console warning for `L.esri.Vector.vectorTileLayer` explaining that only services with a Web Mercator `spatialReference` are fully supported. [#95](https://github.com/Esri/esri-leaflet-vector/pull/95)
+
 ## [3.0.1] - 2021-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ L.esri.Vector.vectorBasemapLayer("ITEM_ID", {
 
 Please see [the documentation](http://esri.github.io/esri-leaflet/api-reference/layers/vector-basemap.html#vector-basemaps) for a list of basemap names you can use (`ArcGIS:Streets`, `ArcGIS:DarkGray`, `ArcGIS:Imagery:Standard`, `OSM:Standard`, etc).
 
-
 ### `L.esri.Vector.vectorTileLayer`
 
 For custom vector tiles layers published from user data. Extends [L.Layer](https://leafletjs.com/reference#layer).
+
+:warning: This only supports services using the Web Mercator projection because it [relies directly upon `mapbox-gl-js v1`](#dependencies). Otherwise, the layer is not guaranteed to display properly. More information is available at <https://docs.mapbox.com/help/glossary/projection/> and <https://github.com/Esri/esri-leaflet-vector/issues/94>.
 
 ```javascript
 L.esri.Vector.vectorTileLayer("ITEM_ID", {

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,6 +1,8 @@
 import { latLng, latLngBounds } from 'leaflet';
 import { request, Support, Util } from 'esri-leaflet';
 
+const WEB_MERCATOR_WKIDS = [3857, 102100, 102113];
+
 /*
   utility to establish a URL for the basemap styles API
   used primarily by VectorBasemapLayer.js
@@ -212,4 +214,8 @@ export function getAttributionData (url, map) {
       Util._updateMapAttribution(obj);
     });
   }
+}
+
+export function isWebMercator (wkid) {
+  return WEB_MERCATOR_WKIDS.indexOf(wkid) >= 0;
 }

--- a/src/VectorTileLayer.js
+++ b/src/VectorTileLayer.js
@@ -1,5 +1,5 @@
 import { Layer, setOptions } from 'leaflet';
-import { loadStyle, formatStyle } from './Util';
+import { loadStyle, formatStyle, isWebMercator } from './Util';
 import { mapboxGLJSLayer } from './MapBoxGLLayer';
 
 export var VectorTileLayer = Layer.extend({
@@ -55,6 +55,14 @@ export var VectorTileLayer = Layer.extend({
       function (error, style, styleUrl, service) {
         if (error) {
           throw new Error(error);
+        }
+
+        if (!isWebMercator(service.tileInfo.spatialReference.wkid)) {
+          console.warn(
+            'This layer is not guaranteed to display properly because its service does not use the Web Mercator projection. The "tileInfo.spatialReference" property is:',
+            service.tileInfo.spatialReference,
+            '\nMore information is available at https://docs.mapbox.com/help/glossary/projection/ and https://github.com/Esri/esri-leaflet-vector/issues/94.'
+          );
         }
 
         // once style object is loaded it must be transformed to be compliant with mapboxGLJSLayer


### PR DESCRIPTION
closes #94 

An example of what this would look like in the FF dev console:

![image](https://user-images.githubusercontent.com/4933392/122592449-e2aa9a00-d029-11eb-9da8-460d03979fb8.png)

Some inspiration was drawn from: https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-SpatialReference.html#isWebMercator

You can test a demo page with:
`L.esri.Vector.vectorTileLayer("https://services.geodataonline.no/arcgis/rest/services/GeocacheVector/GeocacheBasis/VectorTileServer").addTo(map);`