### PR TITLE
issue type templates and stalebot config from esri-leaflet

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: "Bug report"
+description: Report an issue with Esri Leaflet Vector
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! This is for reporting bugs with Esri Leaflet Vector specifically. If you have an issue with Esri Leaflet itself, please go to https://github.com/Esri/esri-leaflet
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: Please include a clear and concise description of the bug. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: A link to a public repository or jsbin (you can start with https://jsbin.com/zutofox/edit) that reproduces the issue, along with a step by step explanation of how to see the issue. If no reproduction case is provided within a reasonable time-frame, the issue will be closed.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "Please include browser console around the time this bug occurred. Please try not to insert an image but copy paste the log text."
+      render: shell
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: Please include which version of Leaflet you are using, which version of Esri Leaflet you are using, and output of `npx envinfo --system --binaries --browsers --npmPackages "{leaflet,esri-leaflet}"`
+      render: shell
+      placeholder: "Leaflet version: `v_._._`. Esri Leaflet version: `v_._._`.  Esri Leaflet Vector version: `v_._._`. ..."
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Information
+      description: Add any other context about the problem here. If you're are *not* using the CDN, please note what loading/bundling library you are using (webpack, rollup, vite, etc)?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/Esri/esri-leaflet/issues/new/choose
+    about: To suggest an idea or report an issue with the documentation site, https://developers.arcgis.com/esri-leaflet, please log the issue in the Esri Leflet repository.
+  - name: Esri Community
+    url: https://community.esri.com/t5/esri-leaflet/ct-p/esri-leaflet
+    about: Ask questions and discuss with other Esri Leaflet users.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: "Feature Request"
+description: Suggest an idea for Esri Leaflet Vector
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request this feature!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the problem
+      description: Please provide a clear and concise description the problem this feature would solve. The more information you can provide here, the better.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the proposed solution
+      description: Please provide a clear and concise description of what you would like to happen.
+      placeholder: I would like to see...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: "Please provide a clear and concise description of any alternative solutions or features you've considered."
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Information
+      description: Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/stale.yml
+++ b/.github/ISSUE_TEMPLATE/stale.yml
@@ -1,0 +1,58 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: ["Comments Needed"]
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because we're waiting on 
+  more information or details, but have not received any response. It will be 
+  closed if no further activity occurs. Thank you!
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   This issue was
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
Added a similar issue type template and stalebot configuration from what Esri Leaflet uses https://github.com/Esri/esri-leaflet/tree/master/.github