### PR TITLE
Error handling and customizable base url and style path

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -40,24 +40,38 @@ export function loadService (serviceUrl, options, callback) {
 
 function loadItem (itemId, options, callback) {
   var params = options.token ? { token: options.token } : {};
-  var url = options.portalUrl +
+  var url = '';
+
+  if (options.useCustomUrlOrPath) {
+    url = options.baseUrl + '/' + itemId;
+  } else {
+    url = options.portalUrl +
     '/sharing/rest/content/items/' +
     itemId;
+  }
+
   request(url, params, callback);
 }
 
 function loadStyleFromItem (itemId, options, callback) {
-  var itemStyleUrl =
-    options.portalUrl +
+  var itemStyleUrl = '';
+
+  if (options.useCustomUrlOrPath) {
+    itemStyleUrl = options.baseUrl + '/' + itemId + '/' + options.stylePath;
+  } else {
+    itemStyleUrl = options.portalUrl +
     '/sharing/rest/content/items/' +
     itemId +
     '/resources/styles/root.json';
+  }
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
     if (error) {
       loadItem(itemId, options, function (error, item) {
         if (error) {
           console.error(error);
+          callback(error);
+          return;
         }
         loadStyleFromService(item.url, options, callback);
       });
@@ -65,6 +79,8 @@ function loadStyleFromItem (itemId, options, callback) {
       loadItem(itemId, options, function (error, item) {
         if (error) {
           console.error(error);
+          callback(error);
+          return;
         }
         loadService(item.url, options, function (error, service) {
           callback(error, style, itemStyleUrl, service, item.url);
@@ -78,6 +94,8 @@ function loadStyleFromService (serviceUrl, options, callback) {
   loadService(serviceUrl, options, function (error, service) {
     if (error) {
       console.error(error);
+      callback(error);
+      return;
     }
 
     var sanitizedServiceUrl = serviceUrl;
@@ -99,6 +117,8 @@ function loadStyleFromService (serviceUrl, options, callback) {
     loadStyleFromUrl(defaultStylesUrl, options, function (error, style) {
       if (error) {
         console.error(error);
+        callback(error);
+        return;
       }
       callback(null, style, defaultStylesUrl, service, serviceUrl);
     });

--- a/src/VectorTileLayer.js
+++ b/src/VectorTileLayer.js
@@ -9,7 +9,16 @@ export var VectorTileLayer = Layer.extend({
     pane: 'overlayPane',
 
     // if portalUrl is not provided, default to ArcGIS Online
-    portalUrl: 'https://www.arcgis.com'
+    portalUrl: 'https://www.arcgis.com',
+
+    // flag to use baseUrl and stylePath options (defaults below)
+    useCustomUrlOrPath: false,
+
+    // if baseUrl is not provided, default path to items on ArcGIS Online
+    baseUrl: 'https://www.arcgis.com/sharing/rest/content/items',
+
+    // if stylePath is not provided, default ArcGIS Online stylePath
+    stylePath: 'resources/styles/root.json'
   },
 
   /**
@@ -57,7 +66,12 @@ export var VectorTileLayer = Layer.extend({
       this.options,
       function (error, style, styleUrl, service) {
         if (error) {
-          throw new Error(error);
+          if (this.options.errorCallback) {
+            this.options.errorCallback(error);
+            return;
+          } else {
+            throw new Error(error);
+          }
         }
 
         if (!isWebMercator(service.tileInfo.spatialReference.wkid)) {
@@ -118,7 +132,9 @@ export var VectorTileLayer = Layer.extend({
   },
 
   onRemove: function (map) {
-    map.removeLayer(this._mapboxGL);
+    if (this._mapboxGL) {
+      map.removeLayer(this._mapboxGL);
+    }
   },
 
   _asyncAdd: function () {

--- a/src/VectorTileLayer.js
+++ b/src/VectorTileLayer.js
@@ -74,6 +74,15 @@ export var VectorTileLayer = Layer.extend({
           }
         }
 
+        if (!style.sources) {
+          if (this.options.errorCallback) {
+            this.options.errorCallback('incorrect style path detected');
+            return;
+          } else {
+            throw new Error('incorrect style path detected');
+          }
+        }
+
         if (!isWebMercator(service.tileInfo.spatialReference.wkid)) {
           console.warn(
             'This layer is not guaranteed to display properly because its service does not use the Web Mercator projection. The "tileInfo.spatialReference" property is:',


### PR DESCRIPTION
Hello Esri-leaflet-vector, 

I implemented some changes in a forked version of this repository. Perhaps some of them might be interesting/useful for you so, I made this PR. I'm happy to add tests/go through the review process if any of it is desirable. It should be noted that the changes were implemented to `vectorTileLayer` only. Below is a list of the changes:

1. Custom `baseUrl` and `stylePath` parameters - In our case, we require paths to the `itemId` that are not the ones hardcoded in the current implementation. So three parameters were added:
* `baseUrl` - The path to where the `itemId` resides (defaults to the previous `portalUrl + <hardcoded-path-to-itemId>` if not specified and `useCustomUrlOrPath` (see below) is not passed as true);
* `stylePath` - The path to the style json. This will be appended to after the `itemId` in the path when retrieving the vectorTileStyle file (defaults to the previous `<hardcoded-path-to-style>` value if not specified and `useCustomUrlOrPath` is not passed as true);
* `useCustomUrlOrPath` - Whether to use baseUrl and stylePath at all. If this is not passed, or passed as false, the previous functionality will happen, this includes the optional use of `portalUrl`.
2. Error handling - If a request is unsuccessful (e.g. due to incorrect itemId, hardcoded stylePath, hardcoded baseUrl, portalUrl), the request logs an error to the console, but then the subsequent request to retrieve the vector tile data from the service failed, which crashed our app due to an uncaught error. Then on subsequent browser refreshes, the app continued to crash (as the incorrect parameters are in local storage). To get around this, I added an optional parameter to the `vectorTileLayer` function called `errorCallback`. This callback function allowed us to handle the error as we usually do in our application;
3. onRemove function - When a layer fails to load, the error is now handled as per point 2. However, in our app there is a function which calls `leafletMap.removeLayer` to clear layers before re-adding them. This triggers the `onRemove` function in `vectorTileLayer` and `map.removeLayer(this._mapboxGL)` was called. The the problem was that `this._mapboxGL` was never initialized because the `_createLayer` function was exited early. So a check was added to make use that `this.mapboxGL` exists before calling remove. 