### PR TITLE
maplibregl.version now supported

### DIFF
--- a/examples/contour-dev.html
+++ b/examples/contour-dev.html
@@ -43,7 +43,7 @@
       "L.version": L.version,
       "L.esri.VERSION": L.esri.VERSION,
       "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      // "maplibregl.version": maplibregl.version // Version is temporarily not working, add back soon: https://github.com/maplibre/maplibre-gl-js/pull/1459
+      "maplibregl.version": maplibregl.version
     });
 
     var map = L.map("map", {}).setView([34.0739, -118.2400], 15);

--- a/examples/custom-vtl-dev.html
+++ b/examples/custom-vtl-dev.html
@@ -43,7 +43,7 @@
       "L.version": L.version,
       "L.esri.VERSION": L.esri.VERSION,
       "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      // "maplibregl.version": maplibregl.version // Version is temporarily not working, add back soon: https://github.com/maplibre/maplibre-gl-js/pull/1459
+      "maplibregl.version": maplibregl.version
     });
 
     var map = L.map("map", {}).setView([34.0522, -118.2437], 15);

--- a/examples/gallery-dev.html
+++ b/examples/gallery-dev.html
@@ -42,7 +42,7 @@
       "L.version": L.version,
       "L.esri.VERSION": L.esri.VERSION,
       "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      // "maplibregl.version": maplibregl.version // Version is temporarily not working, add back soon: https://github.com/maplibre/maplibre-gl-js/pull/1459
+      "maplibregl.version": maplibregl.version
     });
 
     // deeper than zoom level 15, missing tiles may be encountered

--- a/examples/quickstart-dev.html
+++ b/examples/quickstart-dev.html
@@ -43,7 +43,7 @@
       "L.version": L.version,
       "L.esri.VERSION": L.esri.VERSION,
       "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      // "maplibregl.version": maplibregl.version // Version is temporarily not working, add back soon: https://github.com/maplibre/maplibre-gl-js/pull/1459
+      "maplibregl.version": maplibregl.version
     });
 
     var map = L.map("map", {}).setView([34.0522, -118.2437], 15);


### PR DESCRIPTION
As of v2.3.0 of maplibregl-js, the `version` property is now populated: https://github.com/maplibre/maplibre-gl-js/pull/1471  , so I'm adding this back to our example files to aid in debugging.