### PR TITLE
fire load-error

### DIFF
--- a/examples/quickstart-dev.html
+++ b/examples/quickstart-dev.html
@@ -1,57 +1,82 @@
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Esri Leaflet Vector Quickstart (DEV TEST)</title>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Esri Leaflet Vector Quickstart (DEV TEST)</title>
+    <!-- Load Leaflet from CDN or local node_modules -->
+    <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+    <script src="../node_modules/leaflet/dist/leaflet.js"></script>
 
-  <!-- Load Leaflet from CDN or local node_modules -->
-  <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
-  <script src="../node_modules/leaflet/dist/leaflet.js"></script>
-
-  <!--
+    <!--
     Load maplibre-gl from CDN or local node_modules for dev/debug purposes because it is not bundled in Esri Leaflet Vector's dev/debug code
     (note also that loading maplibre-gl.css is not necessary)
   -->
-  <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
+    <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
 
-  <!-- Load Esri Leaflet and Esri Leaflet Vector plugin dev/debug version -->
-  <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
-  <script src="../dist/esri-leaflet-vector-debug.js"></script>
+    <!-- Load Esri Leaflet and Esri Leaflet Vector plugin dev/debug version -->
+    <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
+    <script src="../dist/esri-leaflet-vector-debug.js"></script>
 
-  <!-- But note that maplibre-gl is bundled in Esri Leaflet Vector's production code -->
-  <!-- <script src="../dist/esri-leaflet-vector.js"></script> -->
+    <!-- But note that maplibre-gl is bundled in Esri Leaflet Vector's production code -->
+    <!-- <script src="../dist/esri-leaflet-vector.js"></script> -->
 
-  <style>
-    html,
-    body {
-      margin: 0;
-    }
+    <style>
+      html,
+      body {
+        margin: 0;
+      }
 
-    #map {
-      width: 100%;
-      height: 100%;
-    }
-  </style>
-</head>
+      #map {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
 
-<body>
-  <div id="map"></div>
+  <body>
+    <div id="map"></div>
 
-  <script>
-    console.table({
-      "L.version": L.version,
-      "L.esri.VERSION": L.esri.VERSION,
-      "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      "maplibregl.version": maplibregl.version
-    });
+    <script>
+      console.table({
+        "L.version": L.version,
+        "L.esri.VERSION": L.esri.VERSION,
+        "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
+        "maplibregl.version": maplibregl.version,
+      });
 
-    var map = L.map("map", {}).setView([34.0522, -118.2437], 15);
+      // var map = L.map("map", {}).setView([34.0522, -118.2437], 15);
 
-    L.esri.Vector.vectorBasemapLayer("ArcGIS:Streets", {
-      apiKey: "< YOUR VALID API KEY HERE >"
-    }).addTo(map);
-  </script>
-</body>
+      // L.esri.Vector.vectorBasemapLayer("ArcGIS:Streets", {
+      //   apiKey:
+      //     "AAPK9ab2a22d965b4bdbaed32aff8a3f51d5LzVe1x5uQ3oBM02P-Df3unfnu9WDWFO6BNgIXxhmCtM5_ZNqN7b2BSp8vjMpo92y",
+      // }).addTo(map);
 
+      var map = L.map("map", {}).setView([34.0522, -118.2437], 15);
+
+      // CASE 1 - WRONG VECTORTILELAYER ITEMID
+      // const overlay = new L.esri.Vector.vectorTileLayer('75f4dfdff19e445395653121a95a85db_WRONG', {
+      //   portalUrl: 'https://esri.maps.arcgis.com'
+      // });
+
+      // CASE 2 - WRONG PORTALURL
+      // const overlay = new L.esri.Vector.vectorTileLayer(
+      //   "75f4dfdff19e445395653121a95a85db",
+      //   {
+      //     portalUrl: "https://esriiiii.maps.arcgis.com",
+      //   }
+      // );
+
+      // CASE 3 - WRONG SERVICE URL
+      const overlay = new L.esri.Vector.vectorTileLayer(
+        "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints_WRONG/VectorTileServer"
+      );
+
+      overlay.on("load-error", (e) => {
+        console.log("error", e);
+      });
+
+      overlay.addTo(map);
+    </script>
+  </body>
 </html>

--- a/examples/quickstart-dev.html
+++ b/examples/quickstart-dev.html
@@ -1,82 +1,57 @@
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Esri Leaflet Vector Quickstart (DEV TEST)</title>
 
-    <!-- Load Leaflet from CDN or local node_modules -->
-    <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
-    <script src="../node_modules/leaflet/dist/leaflet.js"></script>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Esri Leaflet Vector Quickstart (DEV TEST)</title>
 
-    <!--
+  <!-- Load Leaflet from CDN or local node_modules -->
+  <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+  <script src="../node_modules/leaflet/dist/leaflet.js"></script>
+
+  <!--
     Load maplibre-gl from CDN or local node_modules for dev/debug purposes because it is not bundled in Esri Leaflet Vector's dev/debug code
     (note also that loading maplibre-gl.css is not necessary)
   -->
-    <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
+  <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
 
-    <!-- Load Esri Leaflet and Esri Leaflet Vector plugin dev/debug version -->
-    <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
-    <script src="../dist/esri-leaflet-vector-debug.js"></script>
+  <!-- Load Esri Leaflet and Esri Leaflet Vector plugin dev/debug version -->
+  <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
+  <script src="../dist/esri-leaflet-vector-debug.js"></script>
 
-    <!-- But note that maplibre-gl is bundled in Esri Leaflet Vector's production code -->
-    <!-- <script src="../dist/esri-leaflet-vector.js"></script> -->
+  <!-- But note that maplibre-gl is bundled in Esri Leaflet Vector's production code -->
+  <!-- <script src="../dist/esri-leaflet-vector.js"></script> -->
 
-    <style>
-      html,
-      body {
-        margin: 0;
-      }
+  <style>
+    html,
+    body {
+      margin: 0;
+    }
 
-      #map {
-        width: 100%;
-        height: 100%;
-      }
-    </style>
-  </head>
+    #map {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
 
-  <body>
-    <div id="map"></div>
+<body>
+  <div id="map"></div>
 
-    <script>
-      console.table({
-        "L.version": L.version,
-        "L.esri.VERSION": L.esri.VERSION,
-        "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-        "maplibregl.version": maplibregl.version,
-      });
+  <script>
+    console.table({
+      "L.version": L.version,
+      "L.esri.VERSION": L.esri.VERSION,
+      "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
+      "maplibregl.version": maplibregl.version
+    });
 
-      // var map = L.map("map", {}).setView([34.0522, -118.2437], 15);
+    var map = L.map("map", {}).setView([34.0522, -118.2437], 15);
 
-      // L.esri.Vector.vectorBasemapLayer("ArcGIS:Streets", {
-      //   apiKey:
-      //     "AAPK9ab2a22d965b4bdbaed32aff8a3f51d5LzVe1x5uQ3oBM02P-Df3unfnu9WDWFO6BNgIXxhmCtM5_ZNqN7b2BSp8vjMpo92y",
-      // }).addTo(map);
+    L.esri.Vector.vectorBasemapLayer("ArcGIS:Streets", {
+      apiKey: "< YOUR VALID API KEY HERE >"
+    }).addTo(map);
+  </script>
+</body>
 
-      var map = L.map("map", {}).setView([34.0522, -118.2437], 15);
-
-      // CASE 1 - WRONG VECTORTILELAYER ITEMID
-      // const overlay = new L.esri.Vector.vectorTileLayer('75f4dfdff19e445395653121a95a85db_WRONG', {
-      //   portalUrl: 'https://esri.maps.arcgis.com'
-      // });
-
-      // CASE 2 - WRONG PORTALURL
-      // const overlay = new L.esri.Vector.vectorTileLayer(
-      //   "75f4dfdff19e445395653121a95a85db",
-      //   {
-      //     portalUrl: "https://esriiiii.maps.arcgis.com",
-      //   }
-      // );
-
-      // CASE 3 - WRONG SERVICE URL
-      const overlay = new L.esri.Vector.vectorTileLayer(
-        "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints_WRONG/VectorTileServer"
-      );
-
-      overlay.on("load-error", (e) => {
-        console.log("error", e);
-      });
-
-      overlay.addTo(map);
-    </script>
-  </body>
 </html>

--- a/spec/VectorTileLayerSpec.js
+++ b/spec/VectorTileLayerSpec.js
@@ -128,11 +128,48 @@ describe('VectorTileLayer', function () {
       })
     );
 
+    server.respondWith(
+      'GET',
+      'https://esri.maps.arcgis.com/sharing/rest/content/items/75f4dfdff19e445395653121a95a85db_WRONG?f=json',
+      JSON.stringify({
+        error: {
+          code: 400,
+          messageCode: 'CONT_0001',
+          message: 'Item does not exist or is inaccessible.',
+          details: []
+        }
+      })
+    );
+
     const layer = new L.esri.Vector.vectorTileLayer(
       '75f4dfdff19e445395653121a95a85db_WRONG',
       {
         portalUrl: 'https://esri.maps.arcgis.com'
       }
+    );
+    layer.on('load-error', function (e) {
+      expect(e.type).to.equal('load-error');
+      done();
+    });
+    server.respond();
+    server.respond();
+  });
+
+  it('should emit load-error for bad service url', function (done) {
+    server.respondWith(
+      'GET',
+      'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints_WRONG/VectorTileServer?f=json',
+      JSON.stringify({
+        error: {
+          code: 404,
+          message: 'Requested Service not available.',
+          details: null
+        }
+      })
+    );
+
+    const layer = new L.esri.Vector.vectorTileLayer(
+      'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints_WRONG/VectorTileServer'
     );
     layer.on('load-error', function (e) {
       expect(e.type).to.equal('load-error');

--- a/spec/VectorTileLayerSpec.js
+++ b/spec/VectorTileLayerSpec.js
@@ -7,12 +7,23 @@ describe('VectorTileLayer', function () {
   const serviceUrl =
     'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer';
   const token = '1234abcd';
+  let server;
 
   // for layers hosted in ArcGIS Enterprise instead of ArcGIS Online
   const onPremisePortalUrl = 'https://PATH/TO/ARCGIS/ENTERPRISE'; // defaults to https://www.arcgis.com
   const onPremiseItemId = '1c365daf37a744fbad748b67aa69dac8';
   const onPremiseServiceUrl =
     'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer';
+
+  beforeEach(function () {
+    server = sinon.fakeServer.create();
+  });
+
+  afterEach(function () {
+    server.restore();
+    map = null;
+    sinon.restore();
+  });
 
   it('should have a L.esri.vectorTileLayer alias', function () {
     console.log('L.esri.Vector.vectorTileLayer', L.esri.Vector.vectorTileLayer);
@@ -101,5 +112,32 @@ describe('VectorTileLayer', function () {
     });
 
     expect(layer.options.portalUrl).to.equal(onPremisePortalUrl);
+  });
+
+  it('should emit load-error for invalid itemID', function (done) {
+    server.respondWith(
+      'GET',
+      'https://esri.maps.arcgis.com/sharing/rest/content/items/75f4dfdff19e445395653121a95a85db_WRONG/resources/styles/root.json?f=json',
+      JSON.stringify({
+        error: {
+          code: 400,
+          messageCode: 'CONT_0001',
+          message: 'Item does not exist or is inaccessible.',
+          details: []
+        }
+      })
+    );
+
+    const layer = new L.esri.Vector.vectorTileLayer(
+      '75f4dfdff19e445395653121a95a85db_WRONG',
+      {
+        portalUrl: 'https://esri.maps.arcgis.com'
+      }
+    );
+    layer.on('load-error', function (e) {
+      expect(e.type).to.equal('load-error');
+      done();
+    });
+    server.respond();
   });
 });

--- a/src/Util.js
+++ b/src/Util.js
@@ -54,7 +54,6 @@ function loadStyleFromItem (itemId, options, callback) {
     '/resources/styles/root.json';
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
-
     if (error) {
       loadItem(itemId, options, function (error, item) {
         if (error) {

--- a/src/Util.js
+++ b/src/Util.js
@@ -54,10 +54,12 @@ function loadStyleFromItem (itemId, options, callback) {
     '/resources/styles/root.json';
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
+
     if (error) {
       loadItem(itemId, options, function (error, item) {
         if (error) {
-          console.error(error);
+          callback(error);
+          return;
         }
         loadStyleFromService(item.url, options, callback);
       });

--- a/src/Util.js
+++ b/src/Util.js
@@ -63,7 +63,8 @@ function loadStyleFromItem (itemId, options, callback) {
     } else {
       loadItem(itemId, options, function (error, item) {
         if (error) {
-          console.error(error);
+          callback(error);
+          return;
         }
         loadService(item.url, options, function (error, service) {
           callback(error, style, itemStyleUrl, service, item.url);
@@ -76,7 +77,8 @@ function loadStyleFromItem (itemId, options, callback) {
 function loadStyleFromService (serviceUrl, options, callback) {
   loadService(serviceUrl, options, function (error, service) {
     if (error) {
-      console.error(error);
+      callback(error);
+      return;
     }
 
     let sanitizedServiceUrl = serviceUrl;
@@ -97,7 +99,8 @@ function loadStyleFromService (serviceUrl, options, callback) {
 
     loadStyleFromUrl(defaultStylesUrl, options, function (error, style) {
       if (error) {
-        console.error(error);
+        callback(error);
+        return;
       }
       callback(null, style, defaultStylesUrl, service, serviceUrl);
     });

--- a/src/VectorTileLayer.js
+++ b/src/VectorTileLayer.js
@@ -59,7 +59,10 @@ export var VectorTileLayer = Layer.extend({
       this.options,
       function (error, style, styleUrl, service) {
         if (error) {
-          throw new Error(error);
+          this.fire('load-error', {
+            value: error
+          });
+          return;
         }
 
         if (!isWebMercator(service.tileInfo.spatialReference.wkid)) {


### PR DESCRIPTION
#146 

@patrickarlt please review. A few thoughts that I could use your feedback on:
1. I have not added a unit test for the error emit - I tried to set it up but could not figure out how to mock an invalid URL with sinon
2. Is the name of the event (`load-error`), what we want?
    - I guess we want to add this to the documentation too .... do we need to add an "Events" section here https://developers.arcgis.com/esri-leaflet/api-reference/layers/vector-layer/#constructor ?


---
update: Here's how I am testing: add this to `quickstart-dev.html` and go through each cases uncommenting it:
- expected: a `console.log('error'` should happen in each case.

```
var map = L.map("map", {}).setView([34.0522, -118.2437], 15);

// CASE 1 - WRONG VECTORTILELAYER ITEMID
// const overlay = new L.esri.Vector.vectorTileLayer('75f4dfdff19e445395653121a95a85db_WRONG', { 
//   portalUrl: 'https://esri.maps.arcgis.com'
// });

// CASE 2 - WRONG PORTALURL
// const overlay = new L.esri.Vector.vectorTileLayer('75f4dfdff19e445395653121a95a85db', { 
//   portalUrl: 'https://esriiiii.maps.arcgis.com'
// });

// CASE 3 - WRONG SERVICE URL
// const overlay = new L.esri.Vector.vectorTileLayer('https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints_WRONG/VectorTileServer');

overlay.on('load-error', (e) => {
  console.log('error', e);
})

overlay.addTo(map);
```