### PR TITLE
Fix #107 by using minLOD/maxLOD

### DIFF
--- a/spec/VectorBasemapLayerSpec.js
+++ b/spec/VectorBasemapLayerSpec.js
@@ -1,5 +1,4 @@
 /* eslint-env mocha */
-// These must be vars (instead of const) due to how the unit tests are run:
 const itemId = '287c07ef752246d08bb4712fd4b74438';
 const apikey = '1234';
 const basemapKey = 'ArcGIS:Streets';

--- a/spec/VectorBasemapLayerSpec.js
+++ b/spec/VectorBasemapLayerSpec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 // These must be vars (instead of const) due to how the unit tests are run:
-var itemId = '287c07ef752246d08bb4712fd4b74438';
-var apikey = '1234';
+const itemId = '287c07ef752246d08bb4712fd4b74438';
+const apikey = '1234';
 const basemapKey = 'ArcGIS:Streets';
 
 describe('VectorBasemapLayer', function () {

--- a/spec/VectorTileLayerSpec.js
+++ b/spec/VectorTileLayerSpec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 // These must be vars (instead of const) due to how the unit tests are run:
-var itemId = '1c365daf37a744fbad748b67aa69dac8';
-var apikey = 'dcba4321';
+const itemId = '1c365daf37a744fbad748b67aa69dac8';
+const apikey = 'dcba4321';
 const serviceUrl = 'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer';
 const token = '1234abcd';
 

--- a/spec/VectorTileLayerSpec.js
+++ b/spec/VectorTileLayerSpec.js
@@ -1,20 +1,25 @@
 /* eslint-env mocha */
-// These must be vars (instead of const) due to how the unit tests are run:
-const itemId = '1c365daf37a744fbad748b67aa69dac8';
-const apikey = 'dcba4321';
-const serviceUrl = 'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer';
-const token = '1234abcd';
-
-// for layers hosted in ArcGIS Enterprise instead of ArcGIS Online
-const onPremisePortalUrl = 'https://PATH/TO/ARCGIS/ENTERPRISE'; // defaults to https://www.arcgis.com
-const onPremiseItemId = '1c365daf37a744fbad748b67aa69dac8';
-const onPremiseServiceUrl = 'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer';
 
 describe('VectorTileLayer', function () {
+  // These must be vars (instead of const) due to how the unit tests are run:
+  const itemId = '1c365daf37a744fbad748b67aa69dac8';
+  const apikey = 'dcba4321';
+  const serviceUrl =
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer';
+  const token = '1234abcd';
+
+  // for layers hosted in ArcGIS Enterprise instead of ArcGIS Online
+  const onPremisePortalUrl = 'https://PATH/TO/ARCGIS/ENTERPRISE'; // defaults to https://www.arcgis.com
+  const onPremiseItemId = '1c365daf37a744fbad748b67aa69dac8';
+  const onPremiseServiceUrl =
+    'https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer';
+
   it('should have a L.esri.vectorTileLayer alias', function () {
     console.log('L.esri.Vector.vectorTileLayer', L.esri.Vector.vectorTileLayer);
 
-    expect(L.esri.Vector.vectorTileLayer(itemId)).to.be.instanceof(L.esri.Vector.VectorTileLayer);
+    expect(L.esri.Vector.vectorTileLayer(itemId)).to.be.instanceof(
+      L.esri.Vector.VectorTileLayer
+    );
   });
 
   it('should save the key from the constructor - itemId', function () {

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,17 +1,17 @@
-import { latLng, latLngBounds } from "leaflet";
-import { request, Support, Util } from "esri-leaflet";
+import { latLng, latLngBounds } from 'leaflet';
+import { request, Support, Util } from 'esri-leaflet';
 
 /*
   utility to establish a URL for the basemap styles API
   used primarily by VectorBasemapLayer.js
 */
-export function getBasemapStyleUrl(key, apikey) {
+export function getBasemapStyleUrl (key, apikey) {
   let url =
-    "https://basemaps-api.arcgis.com/arcgis/rest/services/styles/" +
+    'https://basemaps-api.arcgis.com/arcgis/rest/services/styles/' +
     key +
-    "?type=style";
+    '?type=style';
   if (apikey) {
-    url = url + "&apiKey=" + apikey;
+    url = url + '&apiKey=' + apikey;
   }
   return url;
 }
@@ -20,7 +20,7 @@ export function getBasemapStyleUrl(key, apikey) {
   utilities to communicate with custom user styles via an ITEM ID or SERVICE URL
   used primarily by VectorTileLayer.js
 */
-export function loadStyle(idOrUrl, options, callback) {
+export function loadStyle (idOrUrl, options, callback) {
   const httpRegex = /^https?:\/\//;
   const serviceRegex = /\/VectorTileServer\/?$/;
 
@@ -33,23 +33,23 @@ export function loadStyle(idOrUrl, options, callback) {
   }
 }
 
-export function loadService(serviceUrl, options, callback) {
+export function loadService (serviceUrl, options, callback) {
   const params = options.token ? { token: options.token } : {};
   request(serviceUrl, params, callback);
 }
 
-function loadItem(itemId, options, callback) {
+function loadItem (itemId, options, callback) {
   const params = options.token ? { token: options.token } : {};
-  const url = options.portalUrl + "/sharing/rest/content/items/" + itemId;
+  const url = options.portalUrl + '/sharing/rest/content/items/' + itemId;
   request(url, params, callback);
 }
 
-function loadStyleFromItem(itemId, options, callback) {
+function loadStyleFromItem (itemId, options, callback) {
   const itemStyleUrl =
     options.portalUrl +
-    "/sharing/rest/content/items/" +
+    '/sharing/rest/content/items/' +
     itemId +
-    "/resources/styles/root.json";
+    '/resources/styles/root.json';
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
     if (error) {
@@ -72,7 +72,7 @@ function loadStyleFromItem(itemId, options, callback) {
   });
 }
 
-function loadStyleFromService(serviceUrl, options, callback) {
+function loadStyleFromService (serviceUrl, options, callback) {
   loadService(serviceUrl, options, function (error, service) {
     if (error) {
       console.error(error);
@@ -80,18 +80,18 @@ function loadStyleFromService(serviceUrl, options, callback) {
 
     let sanitizedServiceUrl = serviceUrl;
     // a trailing "/" may create invalid paths
-    if (serviceUrl.charAt(serviceUrl.length - 1) === "/") {
+    if (serviceUrl.charAt(serviceUrl.length - 1) === '/') {
       sanitizedServiceUrl = serviceUrl.slice(0, serviceUrl.length - 1);
     }
 
     let defaultStylesUrl;
     // inadvertently inserting more than 1 adjacent "/" may create invalid paths
-    if (service.defaultStyles.charAt(0) === "/") {
+    if (service.defaultStyles.charAt(0) === '/') {
       defaultStylesUrl =
-        sanitizedServiceUrl + service.defaultStyles + "/root.json";
+        sanitizedServiceUrl + service.defaultStyles + '/root.json';
     } else {
       defaultStylesUrl =
-        sanitizedServiceUrl + "/" + service.defaultStyles + "/root.json";
+        sanitizedServiceUrl + '/' + service.defaultStyles + '/root.json';
     }
 
     loadStyleFromUrl(defaultStylesUrl, options, function (error, style) {
@@ -103,12 +103,12 @@ function loadStyleFromService(serviceUrl, options, callback) {
   });
 }
 
-function loadStyleFromUrl(styleUrl, options, callback) {
+function loadStyleFromUrl (styleUrl, options, callback) {
   const params = options.token ? { token: options.token } : {};
   request(styleUrl, params, callback);
 }
 
-export function formatStyle(style, styleUrl, metadata, token) {
+export function formatStyle (style, styleUrl, metadata, token) {
   // transforms style object in place and also returns it
 
   // modify each source in style.sources
@@ -117,12 +117,12 @@ export function formatStyle(style, styleUrl, metadata, token) {
     const source = style.sources[sourcesKeys[sourceIndex]];
 
     // if a relative path is referenced, the default style can be found in a standard location
-    if (source.url.indexOf("http") === -1) {
-      source.url = styleUrl.replace("/resources/styles/root.json", "");
+    if (source.url.indexOf('http') === -1) {
+      source.url = styleUrl.replace('/resources/styles/root.json', '');
     }
 
     // a trailing "/" may create invalid paths
-    if (source.url.charAt(source.url.length - 1) === "/") {
+    if (source.url.charAt(source.url.length - 1) === '/') {
       source.url = source.url.slice(0, source.url.length - 1);
     }
 
@@ -130,8 +130,8 @@ export function formatStyle(style, styleUrl, metadata, token) {
     if (!source.tiles) {
       // right now ArcGIS Pro published vector services have a slightly different signature
       // the '/' is needed in the URL string concatenation below for source.tiles
-      if (metadata.tiles && metadata.tiles[0].charAt(0) !== "/") {
-        metadata.tiles[0] = "/" + metadata.tiles[0];
+      if (metadata.tiles && metadata.tiles[0].charAt(0) !== '/') {
+        metadata.tiles[0] = '/' + metadata.tiles[0];
       }
 
       source.tiles = [source.url + metadata.tiles[0]];
@@ -139,11 +139,11 @@ export function formatStyle(style, styleUrl, metadata, token) {
 
     // some VectorTileServer endpoints may default to returning f=html,
     // specify f=json to account for that behavior
-    source.url += "?f=json";
+    source.url += '?f=json';
 
     // add the token to the source url and tiles properties as a query param
-    source.url += token ? "&token=" + token : "";
-    source.tiles[0] += token ? "?token=" + token : "";
+    source.url += token ? '&token=' + token : '';
+    source.tiles[0] += token ? '?token=' + token : '';
     console.log(source);
     // add minzoom and maxzoom to each source based on the service metadata
     // prefer minLOD/maxLOD if it exists since that is the level that tiles are cooked too
@@ -156,41 +156,41 @@ export function formatStyle(style, styleUrl, metadata, token) {
 
   // add the attribution and copyrightText properties to the last source in style.sources based on the service metadata
   const lastSource = style.sources[sourcesKeys[sourcesKeys.length - 1]];
-  lastSource.attribution = metadata.copyrightText || "";
-  lastSource.copyrightText = metadata.copyrightText || "";
+  lastSource.attribution = metadata.copyrightText || '';
+  lastSource.copyrightText = metadata.copyrightText || '';
 
   // if any layer in style.layers has a layout.text-font property (it will be any array of strings) remove all items in the array after the first
   for (let layerIndex = 0; layerIndex < style.layers.length; layerIndex++) {
     const layer = style.layers[layerIndex];
     if (
       layer.layout &&
-      layer.layout["text-font"] &&
-      layer.layout["text-font"].length > 1
+      layer.layout['text-font'] &&
+      layer.layout['text-font'].length > 1
     ) {
-      layer.layout["text-font"] = [layer.layout["text-font"][0]];
+      layer.layout['text-font'] = [layer.layout['text-font'][0]];
     }
   }
 
-  if (style.sprite && style.sprite.indexOf("http") === -1) {
+  if (style.sprite && style.sprite.indexOf('http') === -1) {
     // resolve absolute URL for style.sprite
     style.sprite = styleUrl.replace(
-      "styles/root.json",
-      style.sprite.replace("../", "")
+      'styles/root.json',
+      style.sprite.replace('../', '')
     );
 
     // add the token to the style.sprite property as a query param
-    style.sprite += token ? "?token=" + token : "";
+    style.sprite += token ? '?token=' + token : '';
   }
 
-  if (style.glyphs && style.glyphs.indexOf("http") === -1) {
+  if (style.glyphs && style.glyphs.indexOf('http') === -1) {
     // resolve absolute URL for style.glyphs
     style.glyphs = styleUrl.replace(
-      "styles/root.json",
-      style.glyphs.replace("../", "")
+      'styles/root.json',
+      style.glyphs.replace('../', '')
     );
 
     // add the token to the style.glyphs property as a query param
-    style.glyphs += token ? "?token=" + token : "";
+    style.glyphs += token ? '?token=' + token : '';
   }
 
   return style;
@@ -200,7 +200,7 @@ export function formatStyle(style, styleUrl, metadata, token) {
   utility to assist with dynamic attribution data
   used primarily by VectorBasemapLayer.js
 */
-export function getAttributionData(url, map) {
+export function getAttributionData (url, map) {
   if (Support.cors) {
     request(url, {}, function (error, attributions) {
       if (error) {
@@ -219,7 +219,7 @@ export function getAttributionData(url, map) {
             score: coverageArea.score,
             bounds: latLngBounds(southWest, northEast),
             minZoom: coverageArea.zoomMin,
-            maxZoom: coverageArea.zoomMax,
+            maxZoom: coverageArea.zoomMax
           });
         }
       }
@@ -241,6 +241,6 @@ export function getAttributionData(url, map) {
 */
 const WEB_MERCATOR_WKIDS = [3857, 102100, 102113];
 
-export function isWebMercator(wkid) {
+export function isWebMercator (wkid) {
   return WEB_MERCATOR_WKIDS.indexOf(wkid) >= 0;
 }

--- a/src/Util.js
+++ b/src/Util.js
@@ -144,7 +144,6 @@ export function formatStyle (style, styleUrl, metadata, token) {
     // add the token to the source url and tiles properties as a query param
     source.url += token ? '&token=' + token : '';
     source.tiles[0] += token ? '?token=' + token : '';
-    console.log(source);
     // add minzoom and maxzoom to each source based on the service metadata
     // prefer minLOD/maxLOD if it exists since that is the level that tiles are cooked too
     // MapLibre will overzoom for LODs that are not cooked

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,17 +1,17 @@
-import { latLng, latLngBounds } from 'leaflet';
-import { request, Support, Util } from 'esri-leaflet';
+import { latLng, latLngBounds } from "leaflet";
+import { request, Support, Util } from "esri-leaflet";
 
 /*
   utility to establish a URL for the basemap styles API
   used primarily by VectorBasemapLayer.js
 */
-export function getBasemapStyleUrl (key, apikey) {
+export function getBasemapStyleUrl(key, apikey) {
   let url =
-    'https://basemaps-api.arcgis.com/arcgis/rest/services/styles/' +
+    "https://basemaps-api.arcgis.com/arcgis/rest/services/styles/" +
     key +
-    '?type=style';
+    "?type=style";
   if (apikey) {
-    url = url + '&apiKey=' + apikey;
+    url = url + "&apiKey=" + apikey;
   }
   return url;
 }
@@ -20,7 +20,7 @@ export function getBasemapStyleUrl (key, apikey) {
   utilities to communicate with custom user styles via an ITEM ID or SERVICE URL
   used primarily by VectorTileLayer.js
 */
-export function loadStyle (idOrUrl, options, callback) {
+export function loadStyle(idOrUrl, options, callback) {
   const httpRegex = /^https?:\/\//;
   const serviceRegex = /\/VectorTileServer\/?$/;
 
@@ -33,25 +33,23 @@ export function loadStyle (idOrUrl, options, callback) {
   }
 }
 
-export function loadService (serviceUrl, options, callback) {
+export function loadService(serviceUrl, options, callback) {
   const params = options.token ? { token: options.token } : {};
   request(serviceUrl, params, callback);
 }
 
-function loadItem (itemId, options, callback) {
+function loadItem(itemId, options, callback) {
   const params = options.token ? { token: options.token } : {};
-  const url = options.portalUrl +
-    '/sharing/rest/content/items/' +
-    itemId;
+  const url = options.portalUrl + "/sharing/rest/content/items/" + itemId;
   request(url, params, callback);
 }
 
-function loadStyleFromItem (itemId, options, callback) {
+function loadStyleFromItem(itemId, options, callback) {
   const itemStyleUrl =
     options.portalUrl +
-    '/sharing/rest/content/items/' +
+    "/sharing/rest/content/items/" +
     itemId +
-    '/resources/styles/root.json';
+    "/resources/styles/root.json";
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
     if (error) {
@@ -74,7 +72,7 @@ function loadStyleFromItem (itemId, options, callback) {
   });
 }
 
-function loadStyleFromService (serviceUrl, options, callback) {
+function loadStyleFromService(serviceUrl, options, callback) {
   loadService(serviceUrl, options, function (error, service) {
     if (error) {
       console.error(error);
@@ -82,18 +80,18 @@ function loadStyleFromService (serviceUrl, options, callback) {
 
     let sanitizedServiceUrl = serviceUrl;
     // a trailing "/" may create invalid paths
-    if (serviceUrl.charAt(serviceUrl.length - 1) === '/') {
+    if (serviceUrl.charAt(serviceUrl.length - 1) === "/") {
       sanitizedServiceUrl = serviceUrl.slice(0, serviceUrl.length - 1);
     }
 
     let defaultStylesUrl;
     // inadvertently inserting more than 1 adjacent "/" may create invalid paths
-    if (service.defaultStyles.charAt(0) === '/') {
+    if (service.defaultStyles.charAt(0) === "/") {
       defaultStylesUrl =
-        sanitizedServiceUrl + service.defaultStyles + '/root.json';
+        sanitizedServiceUrl + service.defaultStyles + "/root.json";
     } else {
       defaultStylesUrl =
-        sanitizedServiceUrl + '/' + service.defaultStyles + '/root.json';
+        sanitizedServiceUrl + "/" + service.defaultStyles + "/root.json";
     }
 
     loadStyleFromUrl(defaultStylesUrl, options, function (error, style) {
@@ -105,12 +103,12 @@ function loadStyleFromService (serviceUrl, options, callback) {
   });
 }
 
-function loadStyleFromUrl (styleUrl, options, callback) {
+function loadStyleFromUrl(styleUrl, options, callback) {
   const params = options.token ? { token: options.token } : {};
   request(styleUrl, params, callback);
 }
 
-export function formatStyle (style, styleUrl, metadata, token) {
+export function formatStyle(style, styleUrl, metadata, token) {
   // transforms style object in place and also returns it
 
   // modify each source in style.sources
@@ -119,12 +117,12 @@ export function formatStyle (style, styleUrl, metadata, token) {
     const source = style.sources[sourcesKeys[sourceIndex]];
 
     // if a relative path is referenced, the default style can be found in a standard location
-    if (source.url.indexOf('http') === -1) {
-      source.url = styleUrl.replace('/resources/styles/root.json', '');
+    if (source.url.indexOf("http") === -1) {
+      source.url = styleUrl.replace("/resources/styles/root.json", "");
     }
 
     // a trailing "/" may create invalid paths
-    if (source.url.charAt(source.url.length - 1) === '/') {
+    if (source.url.charAt(source.url.length - 1) === "/") {
       source.url = source.url.slice(0, source.url.length - 1);
     }
 
@@ -132,8 +130,8 @@ export function formatStyle (style, styleUrl, metadata, token) {
     if (!source.tiles) {
       // right now ArcGIS Pro published vector services have a slightly different signature
       // the '/' is needed in the URL string concatenation below for source.tiles
-      if (metadata.tiles && metadata.tiles[0].charAt(0) !== '/') {
-        metadata.tiles[0] = '/' + metadata.tiles[0];
+      if (metadata.tiles && metadata.tiles[0].charAt(0) !== "/") {
+        metadata.tiles[0] = "/" + metadata.tiles[0];
       }
 
       source.tiles = [source.url + metadata.tiles[0]];
@@ -141,55 +139,58 @@ export function formatStyle (style, styleUrl, metadata, token) {
 
     // some VectorTileServer endpoints may default to returning f=html,
     // specify f=json to account for that behavior
-    source.url += '?f=json';
+    source.url += "?f=json";
 
     // add the token to the source url and tiles properties as a query param
-    source.url += token ? '&token=' + token : '';
-    source.tiles[0] += token ? '?token=' + token : '';
-
+    source.url += token ? "&token=" + token : "";
+    source.tiles[0] += token ? "?token=" + token : "";
+    console.log(source);
     // add minzoom and maxzoom to each source based on the service metadata
-    source.minzoom = metadata.tileInfo.lods[0].level;
+    // prefer minLOD/maxLOD if it exists since that is the level that tiles are cooked too
+    // MapLibre will overzoom for LODs that are not cooked
+    source.minzoom = metadata.minLOD || metadata.tileInfo.lods[0].level;
     source.maxzoom =
+      metadata.maxLOD ||
       metadata.tileInfo.lods[metadata.tileInfo.lods.length - 1].level;
   }
 
   // add the attribution and copyrightText properties to the last source in style.sources based on the service metadata
   const lastSource = style.sources[sourcesKeys[sourcesKeys.length - 1]];
-  lastSource.attribution = metadata.copyrightText || '';
-  lastSource.copyrightText = metadata.copyrightText || '';
+  lastSource.attribution = metadata.copyrightText || "";
+  lastSource.copyrightText = metadata.copyrightText || "";
 
   // if any layer in style.layers has a layout.text-font property (it will be any array of strings) remove all items in the array after the first
   for (let layerIndex = 0; layerIndex < style.layers.length; layerIndex++) {
     const layer = style.layers[layerIndex];
     if (
       layer.layout &&
-      layer.layout['text-font'] &&
-      layer.layout['text-font'].length > 1
+      layer.layout["text-font"] &&
+      layer.layout["text-font"].length > 1
     ) {
-      layer.layout['text-font'] = [layer.layout['text-font'][0]];
+      layer.layout["text-font"] = [layer.layout["text-font"][0]];
     }
   }
 
-  if (style.sprite && style.sprite.indexOf('http') === -1) {
+  if (style.sprite && style.sprite.indexOf("http") === -1) {
     // resolve absolute URL for style.sprite
     style.sprite = styleUrl.replace(
-      'styles/root.json',
-      style.sprite.replace('../', '')
+      "styles/root.json",
+      style.sprite.replace("../", "")
     );
 
     // add the token to the style.sprite property as a query param
-    style.sprite += token ? '?token=' + token : '';
+    style.sprite += token ? "?token=" + token : "";
   }
 
-  if (style.glyphs && style.glyphs.indexOf('http') === -1) {
+  if (style.glyphs && style.glyphs.indexOf("http") === -1) {
     // resolve absolute URL for style.glyphs
     style.glyphs = styleUrl.replace(
-      'styles/root.json',
-      style.glyphs.replace('../', '')
+      "styles/root.json",
+      style.glyphs.replace("../", "")
     );
 
     // add the token to the style.glyphs property as a query param
-    style.glyphs += token ? '?token=' + token : '';
+    style.glyphs += token ? "?token=" + token : "";
   }
 
   return style;
@@ -199,7 +200,7 @@ export function formatStyle (style, styleUrl, metadata, token) {
   utility to assist with dynamic attribution data
   used primarily by VectorBasemapLayer.js
 */
-export function getAttributionData (url, map) {
+export function getAttributionData(url, map) {
   if (Support.cors) {
     request(url, {}, function (error, attributions) {
       if (error) {
@@ -218,7 +219,7 @@ export function getAttributionData (url, map) {
             score: coverageArea.score,
             bounds: latLngBounds(southWest, northEast),
             minZoom: coverageArea.zoomMin,
-            maxZoom: coverageArea.zoomMax
+            maxZoom: coverageArea.zoomMax,
           });
         }
       }
@@ -240,6 +241,6 @@ export function getAttributionData (url, map) {
 */
 const WEB_MERCATOR_WKIDS = [3857, 102100, 102113];
 
-export function isWebMercator (wkid) {
+export function isWebMercator(wkid) {
   return WEB_MERCATOR_WKIDS.indexOf(wkid) >= 0;
 }


### PR DESCRIPTION
This PR addresses #107 by preferring `minLOD` and `maxLOD` in the service where we find it. From my conversations with the JS API and vector tile teams `minLOD` and `maxLOD` define the upper and lower zooms for which tiles have been cooked. MapLibre will display zooms greater then the `maxLOD`/`maxzoom` by over-scaling the tiles.

Re: #107