### PR TITLE
update export of package version

### DIFF
--- a/src/EsriLeafletVector.js
+++ b/src/EsriLeafletVector.js
@@ -1,6 +1,7 @@
+// export version
 import packageInfo from '../package.json';
-
-export const VERSION = packageInfo.version;
+var version = packageInfo.version;
+export { version as VERSION };
 
 export { VectorBasemapLayer, vectorBasemapLayer } from './VectorBasemapLayer';
 export { VectorTileLayer, vectorTileLayer } from './VectorTileLayer';

--- a/src/EsriLeafletVector.js
+++ b/src/EsriLeafletVector.js
@@ -1,6 +1,6 @@
 // export version
 import packageInfo from '../package.json';
-var version = packageInfo.version;
+const version = packageInfo.version;
 export { version as VERSION };
 
 export { VectorBasemapLayer, vectorBasemapLayer } from './VectorBasemapLayer';

--- a/src/EsriLeafletVector.js
+++ b/src/EsriLeafletVector.js
@@ -1,3 +1,6 @@
-export { version as VERSION } from '../package.json';
+import packageInfo from '../package.json';
+
+export const VERSION = packageInfo.version;
+
 export { VectorBasemapLayer, vectorBasemapLayer } from './VectorBasemapLayer';
 export { VectorTileLayer, vectorTileLayer } from './VectorTileLayer';


### PR DESCRIPTION
The way the export of version is structured when this package is imported, the following build error can occur:

```
./node_modules/esri-leaflet-vector/src/EsriLeafletVector.js:1:0-53 - Error: Should not import the named export 'version' (reexported as 'VERSION') from default-exporting module (only default export is available soon)
```

Specifically I'm seeing this in an Nx +  Angular 15 monorepo environment when building in SSR, but I'm certain others are seeing similar issues caused by this export syntax.