### PR TITLE
Expose MaplibreGLJSLayer Variable

### DIFF
--- a/src/EsriLeafletVector.js
+++ b/src/EsriLeafletVector.js
@@ -5,3 +5,4 @@ export { version as VERSION };
 
 export { VectorBasemapLayer, vectorBasemapLayer } from './VectorBasemapLayer';
 export { VectorTileLayer, vectorTileLayer } from './VectorTileLayer';
+export { MaplibreGLJSLayer, maplibreGLJSLayer } from './MaplibreGLLayer';


### PR DESCRIPTION
We are wanting to implement printing in our application using [this plugin](https://github.com/Igor-Vladyka/leaflet.browser.print), and one of the things that this plugin does is a layer cloning process.  While cloning the `VectorBasemapLayer` does generate the `MaplibreGLJSLayer`, it also throws a warning that it cannot identify this layer.  However, if the `MaplibreGLJSLayer` were exposed this would not be an issue.

Upon looking through the code I could not identify a reason why `MaplibreGLJSLayer` should not be exposed.