### PR TITLE
Allow users to set preserveDrawingBuffer in the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ L.esri.Vector.vectorTileLayer("SERVICE_URL", {
   // (this may not be necessary when specifying a SERVICE_URL)
   portalUrl: "https://www.arcgis.com", // default value
   
+  // optional: set by default to `false` for performance reasons
+  // set to `true` to resolve WebGL printing issues in Firefox
+  preserveDrawingBuffer: false, // default value
+  
   // optional: customize the style with a function that gets the default style from the service
   // and returns the new style to be used
   style: (style) => {

--- a/src/VectorTileLayer.js
+++ b/src/VectorTileLayer.js
@@ -5,7 +5,10 @@ import { maplibreGLJSLayer } from './MaplibreGLLayer';
 export var VectorTileLayer = Layer.extend({
   options: {
     // if portalUrl is not provided, default to ArcGIS Online
-    portalUrl: 'https://www.arcgis.com'
+    portalUrl: 'https://www.arcgis.com',
+    // for performance optimization default to `false`
+    // set to `true` to resolve printing issues in Firefox
+    preserveDrawingBuffer: false
   },
 
   /**
@@ -100,7 +103,8 @@ export var VectorTileLayer = Layer.extend({
     this._maplibreGL = maplibreGLJSLayer({
       style: style,
       pane: this.options.pane,
-      opacity: this.options.opacity
+      opacity: this.options.opacity,
+      preserveDrawingBuffer: this.options.preserveDrawingBuffer
     });
 
     this._ready = true;


### PR DESCRIPTION
It was discovered that printing maps rendered with `esri-leaflet-vector` does not work in Firefox.

An issue was created [here](https://github.com/Esri/esri-leaflet-vector/issues/198).

This PR fixes that issue by allowing the user to set `preserveDrawingBuffer` to `true`, which resolves the issue.  It is set to `false` by default in the `maplibre-gl-js` project in the `scr/ui/map.ts` file for performance optimizations.  Adding the ability for a user to toggle this value through `esri-leaflet-vector`, but maintaining a default of `false` will help users who want to provide printing capabilities, while maintaining the performance optimization for those who do not have this need.