### PR TITLE
Support `maplibre-gl` v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
       "peerDependencies": {
         "esri-leaflet": ">2.3.0",
         "leaflet": "^1.5.0",
-        "maplibre-gl": "^2.0.0 || ^3.0.0"
+        "maplibre-gl": "^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -831,17 +831,19 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.2",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.2.tgz",
-      "integrity": "sha512-C2JAk64XUz9v78+bpyTk1zvgjjnDsB8CCjNumyAYdWK2dvdDtILzh1AGBMdS/llX3KaHjGYxAE5wOwfdwq4Pog==",
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.3.0.tgz",
+      "integrity": "sha512-eSiQ3E5LUSxAOY9ABXGyfNhout2iEa6mUxKeaQ9nJ8NL1NuaQYU7zKqzx/LEYcXe1neT4uYAgM1wYZj3fTSXtA==",
       "peer": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
+        "sort-object": "^3.0.3",
+        "tinyqueue": "^2.0.3"
       },
       "bin": {
         "gl-style-format": "dist/gl-style-format.mjs",
@@ -1261,10 +1263,19 @@
       "dev": true
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
       "peer": true
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1272,16 +1283,22 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/junit-report-builder": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz",
+      "integrity": "sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==",
+      "peer": true
+    },
     "node_modules/@types/mapbox__point-geometry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-      "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
       "peer": true
     },
     "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
-      "integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "peer": true,
       "dependencies": {
         "@types/geojson": "*",
@@ -1299,9 +1316,9 @@
       }
     },
     "node_modules/@types/pbf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-      "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "peer": true
     },
     "node_modules/@types/resolve": {
@@ -1311,9 +1328,9 @@
       "dev": true
     },
     "node_modules/@types/supercluster": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.1.tgz",
-      "integrity": "sha512-dNK02GO1UApgo+1KpY4jOfm3uWb2eBCMB/VMM2y8cMoF49FiqVVcOawEg19wxYcaX7SvEs370incOuFtFGrVLg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "peer": true,
       "dependencies": {
         "@types/geojson": "*"
@@ -3681,9 +3698,9 @@
       }
     },
     "node_modules/geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "peer": true
     },
     "node_modules/get-caller-file": {
@@ -4997,9 +5014,9 @@
       "dev": true
     },
     "node_modules/json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "peer": true
     },
     "node_modules/json5": {
@@ -5672,9 +5689,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.3.1.tgz",
-      "integrity": "sha512-SfRq9bT68GytDzCOG0IoTGg2rASbgdYunW/6xhnp55QuLmwG1M/YOlXxqHaphwia7kZbMvBOocvY0fp5yfTjZA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.5.0.tgz",
+      "integrity": "sha512-qOS1hn4d/pn2i0uva4S5Oz+fACzTkgBKq+NpwT/Tqzi4MSyzcWNtDELzLUSgWqHfNIkGCl5CZ/w7dtis+t4RCw==",
       "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -5684,14 +5701,16 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.0",
-        "@types/geojson": "^7946.0.10",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.0",
-        "@types/pbf": "^3.0.2",
-        "@types/supercluster": "^7.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.0",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/junit-report-builder": "^3.0.2",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
         "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
+        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^3.0.0",
         "kdbush": "^4.0.2",
@@ -9926,17 +9945,19 @@
       "peer": true
     },
     "@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.2",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.2.tgz",
-      "integrity": "sha512-C2JAk64XUz9v78+bpyTk1zvgjjnDsB8CCjNumyAYdWK2dvdDtILzh1AGBMdS/llX3KaHjGYxAE5wOwfdwq4Pog==",
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.3.0.tgz",
+      "integrity": "sha512-eSiQ3E5LUSxAOY9ABXGyfNhout2iEa6mUxKeaQ9nJ8NL1NuaQYU7zKqzx/LEYcXe1neT4uYAgM1wYZj3fTSXtA==",
       "peer": true,
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
+        "sort-object": "^3.0.3",
+        "tinyqueue": "^2.0.3"
       }
     },
     "@octokit/auth-token": {
@@ -10248,10 +10269,19 @@
       "dev": true
     },
     "@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
       "peer": true
+    },
+    "@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "peer": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -10259,16 +10289,22 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/junit-report-builder": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/junit-report-builder/-/junit-report-builder-3.0.2.tgz",
+      "integrity": "sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==",
+      "peer": true
+    },
     "@types/mapbox__point-geometry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
-      "integrity": "sha512-D0lgCq+3VWV85ey1MZVkE8ZveyuvW5VAfuahVTQRpXFQTxw03SuIf1/K4UQ87MMIXVKzpFjXFiFMZzLj2kU+iA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
       "peer": true
     },
     "@types/mapbox__vector-tile": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.0.tgz",
-      "integrity": "sha512-kDwVreQO5V4c8yAxzZVQLE5tyWF+IPToAanloQaSnwfXmIcJ7cyOrv8z4Ft4y7PsLYmhWXmON8MBV8RX0Rgr8g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "peer": true,
       "requires": {
         "@types/geojson": "*",
@@ -10286,9 +10322,9 @@
       }
     },
     "@types/pbf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.2.tgz",
-      "integrity": "sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "peer": true
     },
     "@types/resolve": {
@@ -10298,9 +10334,9 @@
       "dev": true
     },
     "@types/supercluster": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.1.tgz",
-      "integrity": "sha512-dNK02GO1UApgo+1KpY4jOfm3uWb2eBCMB/VMM2y8cMoF49FiqVVcOawEg19wxYcaX7SvEs370incOuFtFGrVLg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "peer": true,
       "requires": {
         "@types/geojson": "*"
@@ -12061,9 +12097,9 @@
       "dev": true
     },
     "geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "peer": true
     },
     "get-caller-file": {
@@ -13026,9 +13062,9 @@
       "dev": true
     },
     "json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "peer": true
     },
     "json5": {
@@ -13580,9 +13616,9 @@
       }
     },
     "maplibre-gl": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-3.3.1.tgz",
-      "integrity": "sha512-SfRq9bT68GytDzCOG0IoTGg2rASbgdYunW/6xhnp55QuLmwG1M/YOlXxqHaphwia7kZbMvBOocvY0fp5yfTjZA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.5.0.tgz",
+      "integrity": "sha512-qOS1hn4d/pn2i0uva4S5Oz+fACzTkgBKq+NpwT/Tqzi4MSyzcWNtDELzLUSgWqHfNIkGCl5CZ/w7dtis+t4RCw==",
       "peer": true,
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -13592,14 +13628,16 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^19.3.0",
-        "@types/geojson": "^7946.0.10",
-        "@types/mapbox__point-geometry": "^0.1.2",
-        "@types/mapbox__vector-tile": "^1.3.0",
-        "@types/pbf": "^3.0.2",
-        "@types/supercluster": "^7.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.0",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/junit-report-builder": "^3.0.2",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
         "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
+        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^3.0.0",
         "kdbush": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "peerDependencies": {
     "esri-leaflet": ">2.3.0",
     "leaflet": "^1.5.0",
-    "maplibre-gl": "^2.0.0 || ^3.0.0"
+    "maplibre-gl": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.1",


### PR DESCRIPTION
Haven't done much more than #201 did

Just updated the peerDependency, and made sure v4 is resolved in the lockfile.

Test results – though I'm not sure the `maplibre-gl` integration is actually covered by tests:
![image](https://github.com/user-attachments/assets/9cd0bbb7-931b-4519-91ed-8de0b3fd02ac)
