### PR TITLE
fix version display for maplibregl v4

### DIFF
--- a/examples/contour-dev.html
+++ b/examples/contour-dev.html
@@ -43,7 +43,7 @@
       "L.version": L.version,
       "L.esri.VERSION": L.esri.VERSION,
       "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      "maplibregl.version": maplibregl.version
+      "maplibregl.version": maplibregl.version || maplibregl.getVersion() // at maplibre-gl@4, must call getVersion
     });
 
     var map = L.map("map", {}).setView([34.0739, -118.2400], 15);

--- a/examples/custom-vtl-dev.html
+++ b/examples/custom-vtl-dev.html
@@ -43,7 +43,7 @@
       "L.version": L.version,
       "L.esri.VERSION": L.esri.VERSION,
       "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      "maplibregl.version": maplibregl.version
+      "maplibregl.version": maplibregl.version || maplibregl.getVersion() // at maplibre-gl@4, must call getVersion
     });
 
     var map = L.map("map", {}).setView([34.0522, -118.2437], 15);

--- a/examples/gallery-dev.html
+++ b/examples/gallery-dev.html
@@ -42,7 +42,7 @@
       "L.version": L.version,
       "L.esri.VERSION": L.esri.VERSION,
       "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      "maplibregl.version": maplibregl.version
+      "maplibregl.version": maplibregl.version || maplibregl.getVersion() // at maplibre-gl@4, must call getVersion
     });
 
     // deeper than zoom level 15, missing tiles may be encountered

--- a/examples/quickstart-dev.html
+++ b/examples/quickstart-dev.html
@@ -43,7 +43,7 @@
       "L.version": L.version,
       "L.esri.VERSION": L.esri.VERSION,
       "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      "maplibregl.version": maplibregl.version
+      "maplibregl.version": maplibregl.version || maplibregl.getVersion() // at maplibre-gl@4, must call getVersion
     });
 
     var map = L.map("map", {}).setView([34.0522, -118.2437], 15);


### PR DESCRIPTION
This is only in `console.log`s in the demo pages.