### PR TITLE
add back "Powered by Esri" attribution for vectorBasemapLayer when using an item ID

### DIFF
--- a/spec/VectorBasemapLayerSpec.js
+++ b/spec/VectorBasemapLayerSpec.js
@@ -314,7 +314,7 @@ describe('VectorBasemapLayer', function () {
       };
 
       layer._setupAttribution();
-      const expectedAttributionValue = '<span class="esri-dynamic-attribution">@ my attribution, @ my copyright text</span>';
+      const expectedAttributionValue = '<span class="esri-dynamic-attribution">Powered by <a href="https://www.esri.com">Esri</a> | @ my attribution, @ my copyright text</span>';
       expect(attributionValue).to.be.equal(expectedAttributionValue);
     });
   });

--- a/src/VectorBasemapLayer.js
+++ b/src/VectorBasemapLayer.js
@@ -2,6 +2,8 @@ import { Util } from 'esri-leaflet';
 import { getBasemapStyleUrl, getAttributionData, getBasemapStyleV2Url } from './Util';
 import { VectorTileLayer } from './VectorTileLayer';
 
+const POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';
+
 export var VectorBasemapLayer = VectorTileLayer.extend({
   /**
    * Populates "this.options" to be used in the rest of the module.
@@ -69,9 +71,6 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
   },
 
   _setupAttribution: function () {
-    // Set attribution
-    Util.setEsriAttribution(this._map);
-
     if (this.options.key.length === 32) {
       // this is an itemId
       const sources = this._maplibreGL.getMaplibreMap().style.stylesheet.sources;
@@ -83,7 +82,10 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
         }
       });
 
-      this._map.attributionControl.addAttribution(`<span class="esri-dynamic-attribution">${allAttributions.join(', ')}</span>`);
+      // In the case of an enum, since the attribution is dynamic, Esri Leaflet
+      // will add the "Powered by Esri" string. But in this case we are not
+      // dynamic so we must add it ourselves.
+      this._map.attributionControl.addAttribution(`<span class="esri-dynamic-attribution">${POWERED_BY_ESRI_ATTRIBUTION_STRING} | ${allAttributions.join(', ')}</span>`);
     } else {
       // this is an enum
       if (!this.options.attributionUrls) {


### PR DESCRIPTION
Issue: #228 

In #135 we added add call to `Util.setEsriAttribution()` to add the "Powered by Esri" attribution, but after Esri Leaflet v3.0.10, calling `Util.setEsriAttribution` does not add "Powered by Esri" anymore. Esri Leaflet only adds "Powered by Esri" for dynamic attribution situations now. So now for non-dynamic situations, we must add the string ourselves.

After this gets released: https://github.com/Esri/esri-leaflet/pull/1397 ... we could use that function so that we do not need to hardcode that string here. But for now I'm adding it since I want to get this in before waiting for an Esri Leaflet release.