### PR TITLE
Handle dynamic attribution properly for both item ids and enums

### DIFF
--- a/src/VectorBasemapLayer.js
+++ b/src/VectorBasemapLayer.js
@@ -1,8 +1,13 @@
-import { Util } from 'esri-leaflet';
-import { getBasemapStyleUrl, getAttributionData, getBasemapStyleV2Url } from './Util';
-import { VectorTileLayer } from './VectorTileLayer';
+import { Util } from "esri-leaflet";
+import {
+  getBasemapStyleUrl,
+  getAttributionData,
+  getBasemapStyleV2Url,
+} from "./Util";
+import { VectorTileLayer } from "./VectorTileLayer";
 
-const POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';
+const POWERED_BY_ESRI_ATTRIBUTION_STRING =
+  'Powered by <a href="https://www.esri.com">Esri</a>';
 
 export var VectorBasemapLayer = VectorTileLayer.extend({
   /**
@@ -14,38 +19,46 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
   initialize: function (key, options) {
     // Default to the v1 service endpoint
     if (!options.version) {
-      if (key.includes('/')) options.version = 2;
+      if (key.includes("/")) options.version = 2;
       else options.version = 1;
     }
     if (!key) {
       // Default style enum if none provided
-      key = options.version === 1 ? 'ArcGIS:Streets' : 'arcgis/streets';
+      key = options.version === 1 ? "ArcGIS:Streets" : "arcgis/streets";
     }
     // If no API Key or token is provided (support outdated casing apiKey of apikey)
     if (!(options.apikey || options.apiKey || options.token)) {
-      throw new Error('An API Key or token is required for vectorBasemapLayer.');
+      throw new Error(
+        "An API Key or token is required for vectorBasemapLayer."
+      );
     }
     // Validate v2 service params
     if (options.version !== 2) {
       if (options.language) {
-        throw new Error('The language parameter is only supported by the basemap styles service v2. Provide a v2 style enumeration to use this option.');
+        throw new Error(
+          "The language parameter is only supported by the basemap styles service v2. Provide a v2 style enumeration to use this option."
+        );
       }
       if (options.worldview) {
-        throw new Error('The worldview parameter is only supported by the basemap styles service v2. Provide a v2 style enumeration to use this option.');
+        throw new Error(
+          "The worldview parameter is only supported by the basemap styles service v2. Provide a v2 style enumeration to use this option."
+        );
       }
       if (options.places) {
-        throw new Error('The places parameter is only supported by the basemap styles service v2. Provide a v2 style enumeration to use this option.');
+        throw new Error(
+          "The places parameter is only supported by the basemap styles service v2. Provide a v2 style enumeration to use this option."
+        );
       }
     }
     // Determine layer order
     if (!options.pane) {
-      if (key.includes(':Label') || key.includes('/label')) {
-        options.pane = 'esri-labels';
-      } else if (key.includes(':Detail') || key.includes('/detail')) {
-        options.pane = 'esri-detail';
+      if (key.includes(":Label") || key.includes("/label")) {
+        options.pane = "esri-labels";
+      } else if (key.includes(":Detail") || key.includes("/detail")) {
+        options.pane = "esri-detail";
       } else {
         // Create layer in the tilePane by default
-        options.pane = 'tilePane';
+        options.pane = "tilePane";
       }
     }
 
@@ -62,7 +75,7 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
       styleUrl = getBasemapStyleV2Url(this.options.key, this.options.apikey, {
         language: this.options.language,
         worldview: this.options.worldview,
-        places: this.options.places
+        places: this.options.places,
       });
     } else {
       styleUrl = getBasemapStyleUrl(this.options.key, this.options.apikey);
@@ -70,16 +83,16 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
     // show error warning on successful response for previous version(1)
     if (this.options.version && this.options.version === 1) {
       fetch(styleUrl)
-        .then(response => {
+        .then((response) => {
           return response.json();
         })
-        .then(styleData => {
+        .then((styleData) => {
           if (styleData.error) {
-            console.warn('Error:', styleData.error.message);
+            console.warn("Error:", styleData.error.message);
           }
         })
-        .catch(error => {
-          console.warn('Error:', error.message);
+        .catch((error) => {
+          console.warn("Error:", error.message);
         });
     }
     this._createMaplibreLayer(styleUrl);
@@ -88,11 +101,17 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
   _setupAttribution: function () {
     if (this.options.key.length === 32) {
       // this is an itemId
-      const sources = this._maplibreGL.getMaplibreMap().style.stylesheet.sources;
+      const sources =
+        this._maplibreGL.getMaplibreMap().style.stylesheet.sources;
       const allAttributions = [];
       Object.keys(sources).forEach(function (key) {
         allAttributions.push(sources[key].attribution);
-        if (sources[key].copyrightText && sources[key].copyrightText && sources[key].copyrightText !== '' && sources[key].attribution !== sources[key].copyrightText) {
+        if (
+          sources[key].copyrightText &&
+          sources[key].copyrightText &&
+          sources[key].copyrightText !== "" &&
+          sources[key].attribution !== sources[key].copyrightText
+        ) {
           allAttributions.push(sources[key].copyrightText);
         }
       });
@@ -100,11 +119,20 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
       // In the case of an enum, since the attribution is dynamic, Esri Leaflet
       // will add the "Powered by Esri" string. But in this case we are not
       // dynamic so we must add it ourselves.
-      this._map.attributionControl.addAttribution(`<span class="esri-dynamic-attribution">${POWERED_BY_ESRI_ATTRIBUTION_STRING} | ${allAttributions.join(', ')}</span>`);
+      this._map.attributionControl.addAttribution(
+        `<span class="esri-dynamic-attribution">${POWERED_BY_ESRI_ATTRIBUTION_STRING} | ${allAttributions.join(
+          ", "
+        )}</span>`
+      );
     } else {
+      // setup dynamic attribution
+      Util.setEsriAttribution(this._map);
+
       // this is an enum
       if (!this.options.attributionUrls) {
-        this.options.attributionUrls = this._getAttributionUrls(this.options.key);
+        this.options.attributionUrls = this._getAttributionUrls(
+          this.options.key
+        );
       }
 
       if (this._map && this.options.attributionUrls) {
@@ -132,28 +160,31 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
    * @param {string} key
    */
   _getAttributionUrls: function (key) {
-    if (key.indexOf('OSM:') === 0 || (key.indexOf('osm/') === 0)) {
-      return ['https://static.arcgis.com/attribution/Vector/OpenStreetMap_v2'];
-    } else if (key.indexOf('ArcGIS:Imagery') === 0 || key.indexOf('arcgis/imagery') === 0) {
+    if (key.indexOf("OSM:") === 0 || key.indexOf("osm/") === 0) {
+      return ["https://static.arcgis.com/attribution/Vector/OpenStreetMap_v2"];
+    } else if (
+      key.indexOf("ArcGIS:Imagery") === 0 ||
+      key.indexOf("arcgis/imagery") === 0
+    ) {
       return [
-        'https://static.arcgis.com/attribution/World_Imagery',
-        'https://static.arcgis.com/attribution/Vector/World_Basemap_v2'
+        "https://static.arcgis.com/attribution/World_Imagery",
+        "https://static.arcgis.com/attribution/Vector/World_Basemap_v2",
       ];
     }
 
     // default:
-    return ['https://static.arcgis.com/attribution/Vector/World_Basemap_v2'];
+    return ["https://static.arcgis.com/attribution/Vector/World_Basemap_v2"];
   },
 
   _initPane: function () {
     if (!this._map.getPane(this.options.pane)) {
       const pane = this._map.createPane(this.options.pane);
-      pane.style.pointerEvents = 'none';
+      pane.style.pointerEvents = "none";
 
       let zIndex = 500;
-      if (this.options.pane === 'esri-detail') {
+      if (this.options.pane === "esri-detail") {
         zIndex = 250;
-      } else if (this.options.pane === 'esri-labels') {
+      } else if (this.options.pane === "esri-labels") {
         zIndex = 300;
       }
       pane.style.zIndex = zIndex;
@@ -161,13 +192,15 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
   },
 
   onRemove: function (map) {
-    map.off('moveend', Util._updateMapAttribution);
+    map.off("moveend", Util._updateMapAttribution);
     map.removeLayer(this._maplibreGL);
 
     if (map.attributionControl) {
       if (Util.removeEsriAttribution) Util.removeEsriAttribution(map);
 
-      const element = document.getElementsByClassName('esri-dynamic-attribution');
+      const element = document.getElementsByClassName(
+        "esri-dynamic-attribution"
+      );
 
       if (element && element.length > 0) {
         const vectorAttribution = element[0].outerHTML;
@@ -175,7 +208,9 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
         // this is needed due to the 2 different ways that addAttribution is called inside _setupAttribution.
         // leaflet attributionControl.removeAttribution method ignore a call when the attribution sent is not present there
         map.attributionControl.removeAttribution(vectorAttribution);
-        map.attributionControl.removeAttribution('<span class="esri-dynamic-attribution"></span>');
+        map.attributionControl.removeAttribution(
+          '<span class="esri-dynamic-attribution"></span>'
+        );
       }
     }
   },
@@ -183,12 +218,12 @@ export var VectorBasemapLayer = VectorTileLayer.extend({
   _asyncAdd: function () {
     const map = this._map;
     this._initPane();
-    map.on('moveend', Util._updateMapAttribution);
+    map.on("moveend", Util._updateMapAttribution);
     this._maplibreGL.addTo(map, this);
-  }
+  },
 });
 
-export function vectorBasemapLayer (key, options) {
+export function vectorBasemapLayer(key, options) {
   return new VectorBasemapLayer(key, options);
 }
 


### PR DESCRIPTION
This should resolve both #234 and #234 which are both caused by the removal os the call to `      Util.setEsriAttribution(this._map)` which sets up the containers for dynamic attribution.

This PR adds this call back but only in the case for enums. Basemaps from portal items will simply use the static attribution returned from the style.