### PR TITLE
Switch to use CDN URLs for style, sprite and glyph URLs

### DIFF
--- a/examples/custom-vtl-dev.html
+++ b/examples/custom-vtl-dev.html
@@ -1,67 +1,69 @@
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Esri Leaflet Vector Custom Vector Tile Layer</title>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Esri Leaflet Vector Custom Vector Tile Layer</title>
+    <!-- Load Leaflet from CDN or local node_modules -->
+    <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+    <script src="../node_modules/leaflet/dist/leaflet.js"></script>
 
-  <!-- Load Leaflet from CDN or local node_modules -->
-  <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
-  <script src="../node_modules/leaflet/dist/leaflet.js"></script>
-
-  <!--
+    <!--
     Load maplibre-gl from CDN or local node_modules for dev/debug purposes because it is not bundled in Esri Leaflet Vector's dev/debug code
     (note also that loading maplibre-gl.css is not necessary)
   -->
-  <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
+    <script src="../node_modules/maplibre-gl/dist/maplibre-gl.js"></script>
 
-  <!-- Load Esri Leaflet and Esri Leaflet Vector plugin dev/debug version -->
-  <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
-  <script src="../dist/esri-leaflet-vector-debug.js"></script>
+    <!-- Load Esri Leaflet and Esri Leaflet Vector plugin dev/debug version -->
+    <script src="../node_modules/esri-leaflet/dist/esri-leaflet.js"></script>
+    <script src="../dist/esri-leaflet-vector-debug.js"></script>
 
-  <!-- But note that maplibre-gl is bundled in Esri Leaflet Vector's production code -->
-  <!-- <script src="../dist/esri-leaflet-vector.js"></script> -->
+    <!-- But note that maplibre-gl is bundled in Esri Leaflet Vector's production code -->
+    <!-- <script src="../dist/esri-leaflet-vector.js"></script> -->
 
-  <style>
-    html,
-    body {
-      margin: 0;
-    }
+    <style>
+      html,
+      body {
+        margin: 0;
+      }
 
-    #map {
-      width: 100%;
-      height: 100%;
-    }
-  </style>
-</head>
+      #map {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
 
-<body>
-  <div id="map"></div>
+  <body>
+    <div id="map"></div>
 
-  <script>
-    console.table({
-      "L.version": L.version,
-      "L.esri.VERSION": L.esri.VERSION,
-      "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
-      "maplibregl.version": maplibregl.version || maplibregl.getVersion() // at maplibre-gl@4, must call getVersion
-    });
+    <script>
+      console.table({
+        "L.version": L.version,
+        "L.esri.VERSION": L.esri.VERSION,
+        "L.esri.Vector.VERSION": L.esri.Vector.VERSION,
+        "maplibregl.version": maplibregl.version || maplibregl.getVersion(), // at maplibre-gl@4, must call getVersion
+      });
 
-    var map = L.map("map", {}).setView([34.0522, -118.2437], 15);
+      var map = L.map("map", {}).setView([34.0522, -118.2437], 15);
 
-    // L.esri.Vector.vectorTileLayer("< ITEM ID or SERVICE URL >", {
-    //   token: "< YOUR VALID TOKEN HERE >",
-    //   style: function(style) {
-    //     return style;
-    //   }
-    // }).addTo(map);
+      // L.esri.Vector.vectorTileLayer("< ITEM ID or SERVICE URL >", {
+      //   token: "< YOUR VALID TOKEN HERE >",
+      //   style: function(style) {
+      //     return style;
+      //   }
+      // }).addTo(map);
 
-    // AGOL content item: https://esri.maps.arcgis.com/home/item.html?id=1c365daf37a744fbad748b67aa69dac8
-    L.esri.Vector.vectorTileLayer("1c365daf37a744fbad748b67aa69dac8").addTo(map);
+      // AGOL content item: https://esri.maps.arcgis.com/home/item.html?id=1c365daf37a744fbad748b67aa69dac8
+      L.esri.Vector.vectorTileLayer("4cf7e1fb9f254dcda9c8fbadb15cf0f8").addTo(
+        map
+      );
 
-    // the following 2 are identical ways to load the layer at this AGOL content item: https://esri.maps.arcgis.com/home/item.html?id=f40326b0dea54330ae39584012807126
-    // L.esri.Vector.vectorTileLayer("f40326b0dea54330ae39584012807126").addTo(map);
-    L.esri.Vector.vectorTileLayer("https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer").addTo(map);
-  </script>
-</body>
-
+      // the following 2 are identical ways to load the layer at this AGOL content item: https://esri.maps.arcgis.com/home/item.html?id=f40326b0dea54330ae39584012807126
+      // L.esri.Vector.vectorTileLayer("f40326b0dea54330ae39584012807126").addTo(map);
+      // L.esri.Vector.vectorTileLayer(
+      //   "https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Microsoft_Building_Footprints/VectorTileServer"
+      // ).addTo(map);
+    </script>
+  </body>
 </html>

--- a/spec/UtilSpec.js
+++ b/spec/UtilSpec.js
@@ -49,16 +49,15 @@ describe('Util', function () {
   });
 
   it('should include the token in the sprite URL when the sprite URL starts with https', function () {
-    const spriteUrl =
-      'https://www.arcgis.com/sharing/rest/content/items/123456789/resources/sprites/sprite-1679474043120';
     const styleUrl =
-      'https://www.arcgis.com/sharing/rest/content/items/asdf/resources/styles/root.json';
+      'https://cdn.arcgis.com/sharing/rest/content/items/asdf/resources/styles/root.json';
     const token = 'asdf';
 
     const style = L.esri.Vector.Util.formatStyle(
       {
         version: 8,
-        sprite: spriteUrl,
+        sprite:
+          'https://www.arcgis.com/sharing/rest/content/items/123456789/resources/sprites/sprite-1679474043120',
         glyphs: '../fonts/{fontstack}/{range}.pbf',
         sources: {
           esri: {
@@ -77,8 +76,10 @@ describe('Util', function () {
       metadata,
       token
     );
-
-    expect(style.sprite).to.equal(`${spriteUrl}?token=${token}`);
+    console.log(style.sprite); // cdn.arcgis.com/sharing/rest/content/items/123456789/resources/sprites/sprite-1679474043120
+    https: expect(style.sprite).to.equal(
+      `https://cdn.arcgis.com/sharing/rest/content/items/123456789/resources/sprites/sprite-1679474043120?token=${token}`
+    );
   });
 
   it('should include the token in the glyph URL when the glyph URL is relative', function () {
@@ -92,7 +93,8 @@ describe('Util', function () {
     const style = L.esri.Vector.Util.formatStyle(
       {
         version: 8,
-        sprite: 'https://www.arcgis.com/sharing/rest/content/items/123456789/resources/sprites/sprite-1679474043120',
+        sprite:
+          'https://www.arcgis.com/sharing/rest/content/items/123456789/resources/sprites/sprite-1679474043120',
         glyphs: glyphUrl,
         sources: {
           esri: {
@@ -117,15 +119,16 @@ describe('Util', function () {
 
   it('should include the token in the glyph URL when the glyph URL starts with https', function () {
     const token = 'asdf';
-    const glyphUrl = 'https://www.arcgis.com/sharing/rest/content/items/123456789//resources/fonts/{fontstack}/{range}.pbf';
     const styleUrl =
-      'https://www.arcgis.com/sharing/rest/content/items/asdf/resources/styles/root.json';
+      'https://cdn.arcgis.com/sharing/rest/content/items/asdf/resources/styles/root.json';
 
     const style = L.esri.Vector.Util.formatStyle(
       {
         version: 8,
-        sprite: 'https://www.arcgis.com/sharing/rest/content/items/123456789/resources/sprites/sprite-1679474043120',
-        glyphs: glyphUrl,
+        sprite:
+          'https://www.arcgis.com/sharing/rest/content/items/123456789/resources/sprites/sprite-1679474043120',
+        glyphs:
+          'https://www.arcgis.com/sharing/rest/content/items/123456789/resources/fonts/{fontstack}/{range}.pbf',
         sources: {
           esri: {
             type: 'vector',
@@ -144,6 +147,8 @@ describe('Util', function () {
       token
     );
 
-    expect(style.glyphs).to.equal(`${glyphUrl}?token=${token}`);
+    expect(style.glyphs).to.equal(
+      `https://cdn.arcgis.com/sharing/rest/content/items/123456789/resources/fonts/{fontstack}/{range}.pbf?token=${token}`
+    );
   });
 });

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,21 +1,23 @@
-import { latLng, latLngBounds } from 'leaflet';
-import { request, Support, Util } from 'esri-leaflet';
+import { latLng, latLngBounds } from "leaflet";
+import { request, Support, Util } from "esri-leaflet";
 
 /*
   utility to establish a URL for the basemap styles API
   used primarily by VectorBasemapLayer.js
 */
-export function getBasemapStyleUrl (style, apikey) {
-  if (style.includes('/')) {
-    throw new Error(style + ' is a v2 style enumeration. Set version:2 to request this style');
+export function getBasemapStyleUrl(style, apikey) {
+  if (style.includes("/")) {
+    throw new Error(
+      style + " is a v2 style enumeration. Set version:2 to request this style"
+    );
   }
 
   let url =
-    'https://basemaps-api.arcgis.com/arcgis/rest/services/styles/' +
+    "https://basemaps-api.arcgis.com/arcgis/rest/services/styles/" +
     style +
-    '?type=style';
+    "?type=style";
   if (apikey) {
-    url = url + '&token=' + apikey;
+    url = url + "&token=" + apikey;
   }
   return url;
 }
@@ -28,34 +30,42 @@ export function getBasemapStyleUrl (style, apikey) {
  * @param {Object} [options] Optional list of options: language, worldview, or places.
  * @returns {string} the URL
  */
-export function getBasemapStyleV2Url (style, token, options) {
-  if (style.includes(':')) {
-    throw new Error(style + ' is a v1 style enumeration. Set version:1 to request this style');
+export function getBasemapStyleV2Url(style, token, options) {
+  if (style.includes(":")) {
+    throw new Error(
+      style + " is a v1 style enumeration. Set version:1 to request this style"
+    );
   }
 
-  let url = 'https://basemapstyles-api.arcgis.com/arcgis/rest/services/styles/v2/styles/';
-  if (!(style.startsWith('osm/') || style.startsWith('arcgis/')) && style.length === 32) {
+  let url =
+    "https://basemapstyles-api.arcgis.com/arcgis/rest/services/styles/v2/styles/";
+  if (
+    !(style.startsWith("osm/") || style.startsWith("arcgis/")) &&
+    style.length === 32
+  ) {
     // style is an itemID
-    url = url + 'items/' + style;
+    url = url + "items/" + style;
 
     if (options.language) {
-      throw new Error('The \'language\' parameter is not supported for custom basemap styles');
+      throw new Error(
+        "The 'language' parameter is not supported for custom basemap styles"
+      );
     }
   } else {
     url = url + style;
   }
 
-  if (!token) throw new Error('A token is required to access basemap styles.');
+  if (!token) throw new Error("A token is required to access basemap styles.");
 
-  url = url + '?token=' + token;
+  url = url + "?token=" + token;
   if (options.language) {
-    url = url + '&language=' + options.language;
+    url = url + "&language=" + options.language;
   }
   if (options.worldview) {
-    url = url + '&worldview=' + options.worldview;
+    url = url + "&worldview=" + options.worldview;
   }
   if (options.places) {
-    url = url + '&places=' + options.places;
+    url = url + "&places=" + options.places;
   }
   return url;
 }
@@ -63,7 +73,7 @@ export function getBasemapStyleV2Url (style, token, options) {
   utilities to communicate with custom user styles via an ITEM ID or SERVICE URL
   used primarily by VectorTileLayer.js
 */
-export function loadStyle (idOrUrl, options, callback) {
+export function loadStyle(idOrUrl, options, callback) {
   const httpRegex = /^https?:\/\//;
   const serviceRegex = /\/VectorTileServer\/?$/;
 
@@ -76,23 +86,23 @@ export function loadStyle (idOrUrl, options, callback) {
   }
 }
 
-export function loadService (serviceUrl, options, callback) {
+export function loadService(serviceUrl, options, callback) {
   const params = options.token ? { token: options.token } : {};
   request(serviceUrl, params, callback);
 }
 
-function loadItem (itemId, options, callback) {
+function loadItem(itemId, options, callback) {
   const params = options.token ? { token: options.token } : {};
-  const url = options.portalUrl + '/sharing/rest/content/items/' + itemId;
+  const url = options.portalUrl + "/sharing/rest/content/items/" + itemId;
   request(url, params, callback);
 }
 
-function loadStyleFromItem (itemId, options, callback) {
+function loadStyleFromItem(itemId, options, callback) {
   const itemStyleUrl =
     options.portalUrl +
-    '/sharing/rest/content/items/' +
+    "/sharing/rest/content/items/" +
     itemId +
-    '/resources/styles/root.json';
+    "/resources/styles/root.json";
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
     if (error) {
@@ -117,7 +127,7 @@ function loadStyleFromItem (itemId, options, callback) {
   });
 }
 
-function loadStyleFromService (serviceUrl, options, callback) {
+function loadStyleFromService(serviceUrl, options, callback) {
   loadService(serviceUrl, options, function (error, service) {
     if (error) {
       callback(error);
@@ -126,18 +136,18 @@ function loadStyleFromService (serviceUrl, options, callback) {
 
     let sanitizedServiceUrl = serviceUrl;
     // a trailing "/" may create invalid paths
-    if (serviceUrl.charAt(serviceUrl.length - 1) === '/') {
+    if (serviceUrl.charAt(serviceUrl.length - 1) === "/") {
       sanitizedServiceUrl = serviceUrl.slice(0, serviceUrl.length - 1);
     }
 
     let defaultStylesUrl;
     // inadvertently inserting more than 1 adjacent "/" may create invalid paths
-    if (service.defaultStyles.charAt(0) === '/') {
+    if (service.defaultStyles.charAt(0) === "/") {
       defaultStylesUrl =
-        sanitizedServiceUrl + service.defaultStyles + '/root.json';
+        sanitizedServiceUrl + service.defaultStyles + "/root.json";
     } else {
       defaultStylesUrl =
-        sanitizedServiceUrl + '/' + service.defaultStyles + '/root.json';
+        sanitizedServiceUrl + "/" + service.defaultStyles + "/root.json";
     }
 
     loadStyleFromUrl(defaultStylesUrl, options, function (error, style) {
@@ -150,30 +160,86 @@ function loadStyleFromService (serviceUrl, options, callback) {
   });
 }
 
-function loadStyleFromUrl (styleUrl, options, callback) {
+function loadStyleFromUrl(styleUrl, options, callback) {
   const params = options.token ? { token: options.token } : {};
   request(styleUrl, params, callback);
 }
 
-function isSameTLD (url1, url2) {
-  return (new URL(url1)).hostname === (new URL(url2)).hostname;
+function isSameTLD(url1, url2) {
+  return new URL(url1).hostname === new URL(url2).hostname;
 }
 
-export function formatStyle (style, styleUrl, metadata, token) {
+/**
+ * Converts an ArcGIS Online URL to a CDN URL to reduce latency and server load. This will not
+ * convert a ArcGIS Enterprise URL since they will be hosting their own resources.
+ *
+ * Borrowed from the JS API.
+ */
+function toCdnUrl(url) {
+  if (!url) {
+    return url || null;
+  }
+
+  let outUrl = url;
+
+  if (outUrl) {
+    outUrl = normalizeArcGISOnlineOrgDomain(outUrl);
+    outUrl = outUrl.replace(
+      /^https?:\/\/www\.arcgis\.com/,
+      "https://cdn.arcgis.com"
+    );
+    outUrl = outUrl.replace(
+      /^https?:\/\/devext\.arcgis\.com/,
+      "https://cdndev.arcgis.com"
+    );
+    outUrl = outUrl.replace(
+      /^https?:\/\/qaext\.arcgis\.com/,
+      "https://cdnqa.arcgis.com"
+    );
+  }
+
+  return outUrl;
+}
+
+/**
+ * Replaces the AGOL org domains with non-org domains.
+ *
+ * Borrowed from the JS API.
+ */
+function normalizeArcGISOnlineOrgDomain(url) {
+  const prdOrg = /^https?:\/\/(?:cdn|[a-z\d-]+\.maps)\.arcgis\.com/i; // https://cdn.arcgis.com or https://x.maps.arcgis.com
+  const devextOrg =
+    /^https?:\/\/(?:cdndev|[a-z\d-]+\.mapsdevext)\.arcgis\.com/i; // https://cdndev.arcgis.com or https://x.mapsdevext.arcgis.com
+  const qaOrg = /^https?:\/\/(?:cdnqa|[a-z\d-]+\.mapsqa)\.arcgis\.com/i; // https://cdnqa.arcgis.com or https://x.mapsqa.arcgis.com
+
+  // replace AGOL org domains with non-org domains
+  if (prdOrg.test(url)) {
+    url = url.replace(prdOrg, "https://www.arcgis.com");
+  } else if (devextOrg.test(url)) {
+    url = url.replace(devextOrg, "https://devext.arcgis.com");
+  } else if (qaOrg.test(url)) {
+    url = url.replace(qaOrg, "https://qaext.arcgis.com");
+  }
+
+  return url;
+}
+
+export function formatStyle(style, styleUrl, metadata, token) {
   // transforms style object in place and also returns it
 
   // modify each source in style.sources
   const sourcesKeys = Object.keys(style.sources);
+
   for (let sourceIndex = 0; sourceIndex < sourcesKeys.length; sourceIndex++) {
     const source = style.sources[sourcesKeys[sourceIndex]];
 
     // if a relative path is referenced, the default style can be found in a standard location
-    if (source.url.indexOf('http') === -1) {
-      source.url = styleUrl.replace('/resources/styles/root.json', '');
+    if (source.url.indexOf("http") === -1) {
+      source.url = styleUrl.replace("/resources/styles/root.json", "");
     }
 
     // a trailing "/" may create invalid paths
-    if (source.url.charAt(source.url.length - 1) === '/') {
+    if (source.url.charAt(source.url.length - 1) === "/") {
       source.url = source.url.slice(0, source.url.length - 1);
     }
 
@@ -181,8 +247,8 @@ export function formatStyle (style, styleUrl, metadata, token) {
     if (!source.tiles) {
       // right now ArcGIS Pro published vector services have a slightly different signature
       // the '/' is needed in the URL string concatenation below for source.tiles
-      if (metadata.tiles && metadata.tiles[0].charAt(0) !== '/') {
-        metadata.tiles[0] = '/' + metadata.tiles[0];
+      if (metadata.tiles && metadata.tiles[0].charAt(0) !== "/") {
+        metadata.tiles[0] = "/" + metadata.tiles[0];
       }
 
       source.tiles = [source.url + metadata.tiles[0]];
@@ -190,11 +256,11 @@ export function formatStyle (style, styleUrl, metadata, token) {
 
     // some VectorTileServer endpoints may default to returning f=html,
     // specify f=json to account for that behavior
-    source.url += '?f=json';
+    source.url += "?f=json";
 
     // add the token to the source url and tiles properties as a query param
-    source.url += token ? '&token=' + token : '';
-    source.tiles[0] += token ? '?token=' + token : '';
+    source.url += token ? "&token=" + token : "";
+    source.tiles[0] += token ? "?token=" + token : "";
     // add minzoom and maxzoom to each source based on the service metadata
     // prefer minLOD/maxLOD if it exists since that is the level that tiles are cooked too
     // MapLibre will overzoom for LODs that are not cooked
@@ -206,51 +272,66 @@ export function formatStyle (style, styleUrl, metadata, token) {
 
   // add the attribution and copyrightText properties to the last source in style.sources based on the service metadata
   const lastSource = style.sources[sourcesKeys[sourcesKeys.length - 1]];
-  lastSource.attribution = metadata.copyrightText || '';
-  lastSource.copyrightText = metadata.copyrightText || '';
+  lastSource.attribution = metadata.copyrightText || "";
+  lastSource.copyrightText = metadata.copyrightText || "";
 
   // if any layer in style.layers has a layout.text-font property (it will be any array of strings) remove all items in the array after the first
   for (let layerIndex = 0; layerIndex < style.layers.length; layerIndex++) {
     const layer = style.layers[layerIndex];
     if (
       layer.layout &&
-      layer.layout['text-font'] &&
-      layer.layout['text-font'].length > 1
+      layer.layout["text-font"] &&
+      layer.layout["text-font"].length > 1
     ) {
-      layer.layout['text-font'] = [layer.layout['text-font'][0]];
+      layer.layout["text-font"] = [layer.layout["text-font"][0]];
     }
   }
 
-  if (style.sprite && style.sprite.indexOf('http') === -1) {
+  if (style.sprite && style.sprite.indexOf("http") === -1) {
     // resolve absolute URL for style.sprite
     style.sprite = styleUrl.replace(
-      'styles/root.json',
-      style.sprite.replace('../', '')
+      "styles/root.json",
+      style.sprite.replace("../", "")
     );
   }
+
+  // Convert the style.glyphs and style.sprite URLs to CDN URLs if possable
+  if (style.glyphs) {
+    style.glyphs = toCdnUrl(style.glyphs);
+  }
+
+  if (style.sprite) {
+    style.sprite = toCdnUrl(style.sprite);
+  }
+
+  // a trailing "/" may create invalid paths
   if (style.sprite && token) {
     // add the token to the style.sprite property as a query param, only if same domain (for token security)
     if (isSameTLD(styleUrl, style.sprite)) {
-      style.sprite += '?token=' + token;
+      style.sprite += "?token=" + token;
     } else {
-      console.warn('Passing a token but sprite URL is not on same base URL, so you must pass the token manually.');
+      console.warn(
+        "Passing a token but sprite URL is not on same base URL, so you must pass the token manually."
+      );
     }
   }
 
-  if (style.glyphs && style.glyphs.indexOf('http') === -1) {
+  if (style.glyphs && style.glyphs.indexOf("http") === -1) {
     // resolve absolute URL for style.glyphs
     style.glyphs = styleUrl.replace(
-      'styles/root.json',
-      style.glyphs.replace('../', '')
+      "styles/root.json",
+      style.glyphs.replace("../", "")
     );
   }
 
   if (style.glyphs && token) {
     // add the token to the style.glyphs property as a query param
     if (isSameTLD(styleUrl, style.glyphs)) {
-      style.glyphs += '?token=' + token;
+      style.glyphs += "?token=" + token;
     } else {
-      console.warn('Passing a token but glyph URL is not on same base URL, so you must pass the token manually.');
+      console.warn(
+        "Passing a token but glyph URL is not on same base URL, so you must pass the token manually."
+      );
     }
   }
 
@@ -261,7 +342,7 @@ export function formatStyle (style, styleUrl, metadata, token) {
   utility to assist with dynamic attribution data
   used primarily by VectorBasemapLayer.js
 */
-export function getAttributionData (url, map) {
+export function getAttributionData(url, map) {
   if (Support.cors) {
     request(url, {}, function (error, attributions) {
       if (error) {
@@ -280,7 +361,7 @@ export function getAttributionData (url, map) {
             score: coverageArea.score,
             bounds: latLngBounds(southWest, northEast),
             minZoom: coverageArea.zoomMin,
-            maxZoom: coverageArea.zoomMax
+            maxZoom: coverageArea.zoomMax,
           });
         }
       }
@@ -302,12 +383,12 @@ export function getAttributionData (url, map) {
 */
 const WEB_MERCATOR_WKIDS = [3857, 102100, 102113];
 
-export function isWebMercator (wkid) {
+export function isWebMercator(wkid) {
   return WEB_MERCATOR_WKIDS.indexOf(wkid) >= 0;
 }
 
 export var EsriUtil = {
-  formatStyle: formatStyle
+  formatStyle: formatStyle,
 };
 
 export default EsriUtil;

--- a/src/Util.js
+++ b/src/Util.js
@@ -98,11 +98,12 @@ function loadItem (itemId, options, callback) {
 }
 
 function loadStyleFromItem (itemId, options, callback) {
-  const itemStyleUrl =
+  const itemStyleUrl = toCdnUrl(
     options.portalUrl +
-    '/sharing/rest/content/items/' +
-    itemId +
-    '/resources/styles/root.json';
+      '/sharing/rest/content/items/' +
+      itemId +
+      '/resources/styles/root.json'
+  );
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
     if (error) {

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,23 +1,23 @@
-import { latLng, latLngBounds } from "leaflet";
-import { request, Support, Util } from "esri-leaflet";
+import { latLng, latLngBounds } from 'leaflet';
+import { request, Support, Util } from 'esri-leaflet';
 
 /*
   utility to establish a URL for the basemap styles API
   used primarily by VectorBasemapLayer.js
 */
-export function getBasemapStyleUrl(style, apikey) {
-  if (style.includes("/")) {
+export function getBasemapStyleUrl (style, apikey) {
+  if (style.includes('/')) {
     throw new Error(
-      style + " is a v2 style enumeration. Set version:2 to request this style"
+      style + ' is a v2 style enumeration. Set version:2 to request this style'
     );
   }
 
   let url =
-    "https://basemaps-api.arcgis.com/arcgis/rest/services/styles/" +
+    'https://basemaps-api.arcgis.com/arcgis/rest/services/styles/' +
     style +
-    "?type=style";
+    '?type=style';
   if (apikey) {
-    url = url + "&token=" + apikey;
+    url = url + '&token=' + apikey;
   }
   return url;
 }
@@ -30,21 +30,21 @@ export function getBasemapStyleUrl(style, apikey) {
  * @param {Object} [options] Optional list of options: language, worldview, or places.
  * @returns {string} the URL
  */
-export function getBasemapStyleV2Url(style, token, options) {
-  if (style.includes(":")) {
+export function getBasemapStyleV2Url (style, token, options) {
+  if (style.includes(':')) {
     throw new Error(
-      style + " is a v1 style enumeration. Set version:1 to request this style"
+      style + ' is a v1 style enumeration. Set version:1 to request this style'
     );
   }
 
   let url =
-    "https://basemapstyles-api.arcgis.com/arcgis/rest/services/styles/v2/styles/";
+    'https://basemapstyles-api.arcgis.com/arcgis/rest/services/styles/v2/styles/';
   if (
-    !(style.startsWith("osm/") || style.startsWith("arcgis/")) &&
+    !(style.startsWith('osm/') || style.startsWith('arcgis/')) &&
     style.length === 32
   ) {
     // style is an itemID
-    url = url + "items/" + style;
+    url = url + 'items/' + style;
 
     if (options.language) {
       throw new Error(
@@ -55,17 +55,17 @@ export function getBasemapStyleV2Url(style, token, options) {
     url = url + style;
   }
 
-  if (!token) throw new Error("A token is required to access basemap styles.");
+  if (!token) throw new Error('A token is required to access basemap styles.');
 
-  url = url + "?token=" + token;
+  url = url + '?token=' + token;
   if (options.language) {
-    url = url + "&language=" + options.language;
+    url = url + '&language=' + options.language;
   }
   if (options.worldview) {
-    url = url + "&worldview=" + options.worldview;
+    url = url + '&worldview=' + options.worldview;
   }
   if (options.places) {
-    url = url + "&places=" + options.places;
+    url = url + '&places=' + options.places;
   }
   return url;
 }
@@ -73,7 +73,7 @@ export function getBasemapStyleV2Url(style, token, options) {
   utilities to communicate with custom user styles via an ITEM ID or SERVICE URL
   used primarily by VectorTileLayer.js
 */
-export function loadStyle(idOrUrl, options, callback) {
+export function loadStyle (idOrUrl, options, callback) {
   const httpRegex = /^https?:\/\//;
   const serviceRegex = /\/VectorTileServer\/?$/;
 
@@ -86,23 +86,23 @@ export function loadStyle(idOrUrl, options, callback) {
   }
 }
 
-export function loadService(serviceUrl, options, callback) {
+export function loadService (serviceUrl, options, callback) {
   const params = options.token ? { token: options.token } : {};
   request(serviceUrl, params, callback);
 }
 
-function loadItem(itemId, options, callback) {
+function loadItem (itemId, options, callback) {
   const params = options.token ? { token: options.token } : {};
-  const url = options.portalUrl + "/sharing/rest/content/items/" + itemId;
+  const url = options.portalUrl + '/sharing/rest/content/items/' + itemId;
   request(url, params, callback);
 }
 
-function loadStyleFromItem(itemId, options, callback) {
+function loadStyleFromItem (itemId, options, callback) {
   const itemStyleUrl =
     options.portalUrl +
-    "/sharing/rest/content/items/" +
+    '/sharing/rest/content/items/' +
     itemId +
-    "/resources/styles/root.json";
+    '/resources/styles/root.json';
 
   loadStyleFromUrl(itemStyleUrl, options, function (error, style) {
     if (error) {
@@ -127,7 +127,7 @@ function loadStyleFromItem(itemId, options, callback) {
   });
 }
 
-function loadStyleFromService(serviceUrl, options, callback) {
+function loadStyleFromService (serviceUrl, options, callback) {
   loadService(serviceUrl, options, function (error, service) {
     if (error) {
       callback(error);
@@ -136,18 +136,18 @@ function loadStyleFromService(serviceUrl, options, callback) {
 
     let sanitizedServiceUrl = serviceUrl;
     // a trailing "/" may create invalid paths
-    if (serviceUrl.charAt(serviceUrl.length - 1) === "/") {
+    if (serviceUrl.charAt(serviceUrl.length - 1) === '/') {
       sanitizedServiceUrl = serviceUrl.slice(0, serviceUrl.length - 1);
     }
 
     let defaultStylesUrl;
     // inadvertently inserting more than 1 adjacent "/" may create invalid paths
-    if (service.defaultStyles.charAt(0) === "/") {
+    if (service.defaultStyles.charAt(0) === '/') {
       defaultStylesUrl =
-        sanitizedServiceUrl + service.defaultStyles + "/root.json";
+        sanitizedServiceUrl + service.defaultStyles + '/root.json';
     } else {
       defaultStylesUrl =
-        sanitizedServiceUrl + "/" + service.defaultStyles + "/root.json";
+        sanitizedServiceUrl + '/' + service.defaultStyles + '/root.json';
     }
 
     loadStyleFromUrl(defaultStylesUrl, options, function (error, style) {
@@ -160,12 +160,12 @@ function loadStyleFromService(serviceUrl, options, callback) {
   });
 }
 
-function loadStyleFromUrl(styleUrl, options, callback) {
+function loadStyleFromUrl (styleUrl, options, callback) {
   const params = options.token ? { token: options.token } : {};
   request(styleUrl, params, callback);
 }
 
-function isSameTLD(url1, url2) {
+function isSameTLD (url1, url2) {
   return new URL(url1).hostname === new URL(url2).hostname;
 }
 
@@ -175,7 +175,7 @@ function isSameTLD(url1, url2) {
  *
  * Borrowed from the JS API.
  */
-function toCdnUrl(url) {
+function toCdnUrl (url) {
   if (!url) {
     return url || null;
   }
@@ -186,15 +186,15 @@ function toCdnUrl(url) {
     outUrl = normalizeArcGISOnlineOrgDomain(outUrl);
     outUrl = outUrl.replace(
       /^https?:\/\/www\.arcgis\.com/,
-      "https://cdn.arcgis.com"
+      'https://cdn.arcgis.com'
     );
     outUrl = outUrl.replace(
       /^https?:\/\/devext\.arcgis\.com/,
-      "https://cdndev.arcgis.com"
+      'https://cdndev.arcgis.com'
     );
     outUrl = outUrl.replace(
       /^https?:\/\/qaext\.arcgis\.com/,
-      "https://cdnqa.arcgis.com"
+      'https://cdnqa.arcgis.com'
     );
   }
 
@@ -206,7 +206,7 @@ function toCdnUrl(url) {
  *
  * Borrowed from the JS API.
  */
-function normalizeArcGISOnlineOrgDomain(url) {
+function normalizeArcGISOnlineOrgDomain (url) {
   const prdOrg = /^https?:\/\/(?:cdn|[a-z\d-]+\.maps)\.arcgis\.com/i; // https://cdn.arcgis.com or https://x.maps.arcgis.com
   const devextOrg =
     /^https?:\/\/(?:cdndev|[a-z\d-]+\.mapsdevext)\.arcgis\.com/i; // https://cdndev.arcgis.com or https://x.mapsdevext.arcgis.com
@@ -214,17 +214,17 @@ function normalizeArcGISOnlineOrgDomain(url) {
 
   // replace AGOL org domains with non-org domains
   if (prdOrg.test(url)) {
-    url = url.replace(prdOrg, "https://www.arcgis.com");
+    url = url.replace(prdOrg, 'https://www.arcgis.com');
   } else if (devextOrg.test(url)) {
-    url = url.replace(devextOrg, "https://devext.arcgis.com");
+    url = url.replace(devextOrg, 'https://devext.arcgis.com');
   } else if (qaOrg.test(url)) {
-    url = url.replace(qaOrg, "https://qaext.arcgis.com");
+    url = url.replace(qaOrg, 'https://qaext.arcgis.com');
   }
 
   return url;
 }
 
-export function formatStyle(style, styleUrl, metadata, token) {
+export function formatStyle (style, styleUrl, metadata, token) {
   // transforms style object in place and also returns it
 
   // modify each source in style.sources
@@ -234,12 +234,12 @@ export function formatStyle(style, styleUrl, metadata, token) {
     const source = style.sources[sourcesKeys[sourceIndex]];
 
     // if a relative path is referenced, the default style can be found in a standard location
-    if (source.url.indexOf("http") === -1) {
-      source.url = styleUrl.replace("/resources/styles/root.json", "");
+    if (source.url.indexOf('http') === -1) {
+      source.url = styleUrl.replace('/resources/styles/root.json', '');
     }
 
     // a trailing "/" may create invalid paths
-    if (source.url.charAt(source.url.length - 1) === "/") {
+    if (source.url.charAt(source.url.length - 1) === '/') {
       source.url = source.url.slice(0, source.url.length - 1);
     }
 
@@ -247,8 +247,8 @@ export function formatStyle(style, styleUrl, metadata, token) {
     if (!source.tiles) {
       // right now ArcGIS Pro published vector services have a slightly different signature
       // the '/' is needed in the URL string concatenation below for source.tiles
-      if (metadata.tiles && metadata.tiles[0].charAt(0) !== "/") {
-        metadata.tiles[0] = "/" + metadata.tiles[0];
+      if (metadata.tiles && metadata.tiles[0].charAt(0) !== '/') {
+        metadata.tiles[0] = '/' + metadata.tiles[0];
       }
 
       source.tiles = [source.url + metadata.tiles[0]];
@@ -256,11 +256,11 @@ export function formatStyle(style, styleUrl, metadata, token) {
 
     // some VectorTileServer endpoints may default to returning f=html,
     // specify f=json to account for that behavior
-    source.url += "?f=json";
+    source.url += '?f=json';
 
     // add the token to the source url and tiles properties as a query param
-    source.url += token ? "&token=" + token : "";
-    source.tiles[0] += token ? "?token=" + token : "";
+    source.url += token ? '&token=' + token : '';
+    source.tiles[0] += token ? '?token=' + token : '';
     // add minzoom and maxzoom to each source based on the service metadata
     // prefer minLOD/maxLOD if it exists since that is the level that tiles are cooked too
     // MapLibre will overzoom for LODs that are not cooked
@@ -272,26 +272,26 @@ export function formatStyle(style, styleUrl, metadata, token) {
 
   // add the attribution and copyrightText properties to the last source in style.sources based on the service metadata
   const lastSource = style.sources[sourcesKeys[sourcesKeys.length - 1]];
-  lastSource.attribution = metadata.copyrightText || "";
-  lastSource.copyrightText = metadata.copyrightText || "";
+  lastSource.attribution = metadata.copyrightText || '';
+  lastSource.copyrightText = metadata.copyrightText || '';
 
   // if any layer in style.layers has a layout.text-font property (it will be any array of strings) remove all items in the array after the first
   for (let layerIndex = 0; layerIndex < style.layers.length; layerIndex++) {
     const layer = style.layers[layerIndex];
     if (
       layer.layout &&
-      layer.layout["text-font"] &&
-      layer.layout["text-font"].length > 1
+      layer.layout['text-font'] &&
+      layer.layout['text-font'].length > 1
     ) {
-      layer.layout["text-font"] = [layer.layout["text-font"][0]];
+      layer.layout['text-font'] = [layer.layout['text-font'][0]];
     }
   }
 
-  if (style.sprite && style.sprite.indexOf("http") === -1) {
+  if (style.sprite && style.sprite.indexOf('http') === -1) {
     // resolve absolute URL for style.sprite
     style.sprite = styleUrl.replace(
-      "styles/root.json",
-      style.sprite.replace("../", "")
+      'styles/root.json',
+      style.sprite.replace('../', '')
     );
   }
 
@@ -308,29 +308,29 @@ export function formatStyle(style, styleUrl, metadata, token) {
   if (style.sprite && token) {
     // add the token to the style.sprite property as a query param, only if same domain (for token security)
     if (isSameTLD(styleUrl, style.sprite)) {
-      style.sprite += "?token=" + token;
+      style.sprite += '?token=' + token;
     } else {
       console.warn(
-        "Passing a token but sprite URL is not on same base URL, so you must pass the token manually."
+        'Passing a token but sprite URL is not on same base URL, so you must pass the token manually.'
       );
     }
   }
 
-  if (style.glyphs && style.glyphs.indexOf("http") === -1) {
+  if (style.glyphs && style.glyphs.indexOf('http') === -1) {
     // resolve absolute URL for style.glyphs
     style.glyphs = styleUrl.replace(
-      "styles/root.json",
-      style.glyphs.replace("../", "")
+      'styles/root.json',
+      style.glyphs.replace('../', '')
     );
   }
 
   if (style.glyphs && token) {
     // add the token to the style.glyphs property as a query param
     if (isSameTLD(styleUrl, style.glyphs)) {
-      style.glyphs += "?token=" + token;
+      style.glyphs += '?token=' + token;
     } else {
       console.warn(
-        "Passing a token but glyph URL is not on same base URL, so you must pass the token manually."
+        'Passing a token but glyph URL is not on same base URL, so you must pass the token manually.'
       );
     }
   }
@@ -342,7 +342,7 @@ export function formatStyle(style, styleUrl, metadata, token) {
   utility to assist with dynamic attribution data
   used primarily by VectorBasemapLayer.js
 */
-export function getAttributionData(url, map) {
+export function getAttributionData (url, map) {
   if (Support.cors) {
     request(url, {}, function (error, attributions) {
       if (error) {
@@ -361,7 +361,7 @@ export function getAttributionData(url, map) {
             score: coverageArea.score,
             bounds: latLngBounds(southWest, northEast),
             minZoom: coverageArea.zoomMin,
-            maxZoom: coverageArea.zoomMax,
+            maxZoom: coverageArea.zoomMax
           });
         }
       }
@@ -383,12 +383,12 @@ export function getAttributionData(url, map) {
 */
 const WEB_MERCATOR_WKIDS = [3857, 102100, 102113];
 
-export function isWebMercator(wkid) {
+export function isWebMercator (wkid) {
   return WEB_MERCATOR_WKIDS.indexOf(wkid) >= 0;
 }
 
 export var EsriUtil = {
-  formatStyle: formatStyle,
+  formatStyle: formatStyle
 };
 
 export default EsriUtil;


### PR DESCRIPTION
This PR adds support for switching URLs for the style, sprites and glyphs to the CDN. This should reduce load times and load on the database since this will cache token validation at the edge in the cache key.

This should only apply to `VectorTileLayer`s loaded with a custom item id. If a service URL is used then this should apply to sprites and glyph but no the style URL. This approach should work for all ArcGIS Online items.