### PR TITLE
Fix _transitionEnd method to return early if _map is not defined

### DIFF
--- a/src/MaplibreGLLayer.js
+++ b/src/MaplibreGLLayer.js
@@ -307,6 +307,9 @@ export const MaplibreGLJSLayer = Layer.extend({
 
   _transitionEnd() {
     Util.requestAnimFrame(function () {
+      if (!this._map) {
+        return;
+      }
       const zoom = this._map.getZoom();
       const center = this._map.getCenter();
       const offset = this._map.latLngToContainerPoint(


### PR DESCRIPTION
Our app encountered an error where `this._map` was undefined when the callback function in `_transitionEnd()` was executed. Since `Util.requestAnimFrame()` is an asynchronous operation, the map reference can become undefined by the time the callback runs (e.g., if the layer is removed from the map before the animation frame is processed).